### PR TITLE
Harden auth, ticketing, notifications, and payments

### DIFF
--- a/src/config/__tests__/auth.test.ts
+++ b/src/config/__tests__/auth.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('auth configuration', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('builds absolute redirect URLs when browser location is available', async () => {
+    const fakeLocation = { origin: 'https://example.com', hostname: 'example.com' } as Pick<Location, 'origin' | 'hostname'>;
+    vi.stubGlobal('window', { location: fakeLocation } as unknown as Window);
+    vi.stubGlobal('location', fakeLocation as unknown as Location);
+    vi.resetModules();
+
+    const { AUTH_CONFIG, getRedirectUrl } = await import('../auth');
+
+    expect(AUTH_CONFIG.REDIRECT_URLS.PASSWORD_RESET).toBe('https://example.com/reset-password');
+    expect(getRedirectUrl('PASSWORD_RESET')).toBe('https://example.com/reset-password');
+  });
+
+  it('falls back to relative URLs when window is unavailable', async () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('location', undefined);
+    vi.resetModules();
+
+    const { AUTH_CONFIG, getRedirectUrl } = await import('../auth');
+
+    expect(AUTH_CONFIG.REDIRECT_URLS.PASSWORD_RESET).toBe('/reset-password');
+    expect(getRedirectUrl('PASSWORD_RESET')).toBe('/reset-password');
+  });
+
+  it('validates password requirements with overrides', async () => {
+    vi.resetModules();
+    const { validatePassword } = await import('../auth');
+
+    const short = validatePassword('short');
+    expect(short.isValid).toBe(false);
+    expect(short.errors).toContain('Le mot de passe doit contenir au moins 8 caractères');
+
+    const missingNumber = validatePassword('Password!', { REQUIRE_NUMBERS: true });
+    expect(missingNumber.isValid).toBe(false);
+    expect(missingNumber.errors).toContain('Le mot de passe doit contenir au moins un chiffre');
+
+    const strong = validatePassword('Str0ngPass!', {
+      REQUIRE_UPPERCASE: true,
+      REQUIRE_LOWERCASE: true,
+      REQUIRE_NUMBERS: true,
+      REQUIRE_SPECIAL_CHARS: true,
+    });
+
+    expect(strong.isValid).toBe(true);
+    expect(strong.errors).toHaveLength(0);
+  });
+});

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -1,21 +1,64 @@
-// Authentication configuration
+const REDIRECT_PATHS = {
+  PASSWORD_RESET: '/reset-password',
+  EMAIL_CONFIRMATION: '/login',
+  OAUTH_REDIRECT: '/dashboard',
+} as const;
+
+type RedirectType = keyof typeof REDIRECT_PATHS;
+
+type MaybeLocation = Pick<Location, 'origin' | 'hostname'>;
+
+const getBrowserLocation = (): MaybeLocation | undefined => {
+  if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
+    return window.location;
+  }
+
+  const globalLocation = (globalThis as { location?: MaybeLocation }).location;
+  return globalLocation;
+};
+
+const normalizeOrigin = (origin?: string): string => {
+  if (!origin) {
+    return '';
+  }
+
+  return origin.replace(/\/$/, '');
+};
+
+const ensureLeadingSlash = (path: string): string => {
+  if (!path.startsWith('/')) {
+    return `/${path}`;
+  }
+
+  return path;
+};
+
+const buildRedirectUrl = (path: string, location = getBrowserLocation()): string => {
+  const normalizedPath = ensureLeadingSlash(path);
+  const origin = normalizeOrigin(location?.origin);
+
+  if (!origin) {
+    return normalizedPath;
+  }
+
+  return `${origin}${normalizedPath}`;
+};
+
+const createRedirectUrls = (
+  location = getBrowserLocation(),
+): Record<RedirectType, string> => {
+  return (Object.keys(REDIRECT_PATHS) as RedirectType[]).reduce(
+    (accumulator, key) => {
+      accumulator[key] = buildRedirectUrl(REDIRECT_PATHS[key], location);
+      return accumulator;
+    },
+    {} as Record<RedirectType, string>,
+  );
+};
+
 export const AUTH_CONFIG = {
-  // Base URL for the application
-  BASE_URL: window.location.origin,
-  
-  // Redirect URLs for different authentication flows
-  REDIRECT_URLS: {
-    // Password reset redirect URL
-    PASSWORD_RESET: `${window.location.origin}/reset-password`,
-    
-    // Email confirmation redirect URL (if needed)
-    EMAIL_CONFIRMATION: `${window.location.origin}/login`,
-    
-    // OAuth redirect URL (if needed)
-    OAUTH_REDIRECT: `${window.location.origin}/dashboard`,
-  },
-  
-  // Password requirements
+  BASE_URL: normalizeOrigin(getBrowserLocation()?.origin),
+  REDIRECT_URLS: createRedirectUrls(),
   PASSWORD_REQUIREMENTS: {
     MIN_LENGTH: 8,
     REQUIRE_UPPERCASE: false,
@@ -23,40 +66,65 @@ export const AUTH_CONFIG = {
     REQUIRE_NUMBERS: false,
     REQUIRE_SPECIAL_CHARS: false,
   },
-  
-  // Session configuration
   SESSION: {
     PERSIST_SESSION: true,
     AUTO_REFRESH_TOKEN: true,
     DETECT_SESSION_IN_URL: true,
     FLOW_TYPE: 'pkce' as const,
   },
-};
+} as const;
 
-// Helper function to get the appropriate redirect URL based on environment
-export const getRedirectUrl = (type: keyof typeof AUTH_CONFIG.REDIRECT_URLS): string => {
-  const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-  
-  // For localhost, you might want to use a different URL for testing
+export type PasswordRequirements = typeof AUTH_CONFIG.PASSWORD_REQUIREMENTS;
+
+export const getRedirectUrl = (type: RedirectType): string => {
+  const location = getBrowserLocation();
+
+  if (!location) {
+    return AUTH_CONFIG.REDIRECT_URLS[type];
+  }
+
+  const isLocalhost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+
   if (isLocalhost && type === 'PASSWORD_RESET') {
-    // You can uncomment and modify this line if you want to use a different URL for localhost
-    // return 'https://your-production-domain.com/reset-password';
+    // Placeholder for local overrides if needed in the future.
   }
-  
-  return AUTH_CONFIG.REDIRECT_URLS[type];
+
+  return createRedirectUrls(location)[type];
 };
 
-// Helper function to validate password strength
-export const validatePassword = (password: string): { isValid: boolean; errors: string[] } => {
+export const validatePassword = (
+  password: string,
+  overrides: Partial<PasswordRequirements> = {},
+): { isValid: boolean; errors: string[] } => {
+  const requirements: PasswordRequirements = {
+    ...AUTH_CONFIG.PASSWORD_REQUIREMENTS,
+    ...overrides,
+  };
+
   const errors: string[] = [];
-  const { MIN_LENGTH } = AUTH_CONFIG.PASSWORD_REQUIREMENTS;
-  
-  if (password.length < MIN_LENGTH) {
-    errors.push(`Le mot de passe doit contenir au moins ${MIN_LENGTH} caractères`);
+
+  if (password.length < requirements.MIN_LENGTH) {
+    errors.push(`Le mot de passe doit contenir au moins ${requirements.MIN_LENGTH} caractères`);
   }
-  
+
+  if (requirements.REQUIRE_UPPERCASE && !/[A-Z]/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins une lettre majuscule');
+  }
+
+  if (requirements.REQUIRE_LOWERCASE && !/[a-z]/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins une lettre minuscule');
+  }
+
+  if (requirements.REQUIRE_NUMBERS && !/\d/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins un chiffre');
+  }
+
+  if (requirements.REQUIRE_SPECIAL_CHARS && !/[^A-Za-z0-9]/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins un caractère spécial');
+  }
+
   return {
     isValid: errors.length === 0,
-    errors
+    errors,
   };
-}; 
+};

--- a/src/context/__tests__/EventContext.test.tsx
+++ b/src/context/__tests__/EventContext.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventProvider, useEvents } from '../EventContext';
+import type { EventService } from '../../services/eventService';
+import type { Event } from '../../types/event';
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }));
+
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    error: toastErrorMock,
+  },
+}));
+
+type EventServiceMock = {
+  fetchPublishedEvents: ReturnType<typeof vi.fn>;
+  subscribeToEventChanges: ReturnType<typeof vi.fn>;
+  triggerChange: () => void;
+};
+
+const createServiceMock = (
+  events: Event[],
+  overrides: Partial<EventServiceMock> = {},
+): EventServiceMock => {
+  const fetchPublishedEvents =
+    overrides.fetchPublishedEvents ?? vi.fn().mockResolvedValue(events);
+  let changeHandler: (() => void) | undefined;
+  const unsubscribe = vi.fn().mockResolvedValue('ok');
+  const subscribeToEventChanges =
+    overrides.subscribeToEventChanges ??
+    vi.fn().mockImplementation((handler: () => void) => {
+      changeHandler = handler;
+      return {
+        unsubscribe,
+      };
+    });
+
+  const triggerChange = overrides.triggerChange ?? (() => {
+    changeHandler?.();
+  });
+
+  return {
+    fetchPublishedEvents,
+    subscribeToEventChanges,
+    triggerChange,
+  };
+};
+
+const wrapperFactory = (service: EventServiceMock) => ({ children }: { children: React.ReactNode }) => (
+  <EventProvider service={service as unknown as EventService}>
+    {children}
+  </EventProvider>
+);
+
+const createEvent = (overrides: Partial<Event>): Event => ({
+  id: `event-${Math.random().toString(36).slice(2)}`,
+  title: 'Sample',
+  description: 'Sample description',
+  date: '2024-06-01',
+  time: '18:00',
+  location: 'Paris',
+  image_url: 'https://example.com/image.jpg',
+  price: 42,
+  currency: 'EUR',
+  capacity: 100,
+  tickets_sold: 10,
+  status: 'PUBLISHED',
+  featured: false,
+  ticket_types: [],
+  ...overrides,
+});
+
+describe('EventContext', () => {
+  beforeEach(() => {
+    toastErrorMock.mockReset();
+  });
+
+  const createDeferred = <T,>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+
+  it('loads events on mount, filters featured events, and exposes helpers', async () => {
+    const featuredEvent = createEvent({ id: 'a', featured: true });
+    const duplicateEvent = createEvent({ id: 'a', featured: true });
+    const regularEvent = createEvent({ id: 'b', featured: false });
+
+    const service = createServiceMock([featuredEvent, duplicateEvent, regularEvent]);
+
+    const { result } = renderHook(() => useEvents(), { wrapper: wrapperFactory(service) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(service.fetchPublishedEvents).toHaveBeenCalledTimes(1);
+    expect(result.current.events).toHaveLength(2); // duplicate removed
+    expect(result.current.featuredEvents).toEqual([featuredEvent]);
+    expect(result.current.getEvent('a')).toEqual(featuredEvent);
+  });
+
+  it('refreshes events when fetchEvents is called or when realtime changes occur', async () => {
+    const service = createServiceMock([createEvent({ id: 'a' })]);
+
+    const { result } = renderHook(() => useEvents(), { wrapper: wrapperFactory(service) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(service.fetchPublishedEvents).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.fetchEvents();
+    });
+
+    expect(service.fetchPublishedEvents).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      service.triggerChange();
+    });
+
+    await waitFor(() => expect(service.fetchPublishedEvents).toHaveBeenCalledTimes(3));
+  });
+
+  it('surfaces errors from the service and shows a toast', async () => {
+    const error = new Error('network down');
+    const service = createServiceMock([]);
+    service.fetchPublishedEvents.mockRejectedValueOnce(error);
+    service.fetchPublishedEvents.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useEvents(), { wrapper: wrapperFactory(service) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('network down');
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.fetchEvents();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(service.fetchPublishedEvents).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores stale responses to keep the freshest event list', async () => {
+    const firstDeferred = createDeferred<Event[]>();
+    const secondDeferred = createDeferred<Event[]>();
+    const fetchPublishedEvents = vi
+      .fn<[], Promise<Event[]>>()
+      .mockReturnValueOnce(firstDeferred.promise)
+      .mockReturnValueOnce(secondDeferred.promise);
+
+    const service = createServiceMock([], { fetchPublishedEvents });
+    const { result } = renderHook(() => useEvents(), { wrapper: wrapperFactory(service) });
+
+    await waitFor(() => expect(fetchPublishedEvents).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      service.triggerChange();
+    });
+
+    await waitFor(() => expect(fetchPublishedEvents).toHaveBeenCalledTimes(2));
+
+    const freshEvent = createEvent({ id: 'fresh' });
+    await act(async () => {
+      secondDeferred.resolve([freshEvent]);
+      await secondDeferred.promise;
+    });
+
+    await waitFor(() => expect(result.current.events).toEqual([freshEvent]));
+
+    const staleEvent = createEvent({ id: 'stale' });
+    await act(async () => {
+      firstDeferred.resolve([staleEvent]);
+      await firstDeferred.promise;
+    });
+
+    expect(result.current.events).toEqual([freshEvent]);
+  });
+});
+

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,12 +1,16 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string
-  readonly VITE_ENVIRONMENT: string
+  readonly VITE_API_URL: string;
+  readonly VITE_ENVIRONMENT: string;
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly SUPABASE_URL?: string;
+  readonly SUPABASE_ANON_KEY?: string;
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv;
 }
 
 declare namespace NodeJS {

--- a/src/services/__tests__/authService.test.ts
+++ b/src/services/__tests__/authService.test.ts
@@ -1,0 +1,470 @@
+import type { PostgrestError, Session, SupabaseClient, User } from '@supabase/supabase-js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AuthService, type AuthServiceOptions, type Profile } from '../authService';
+import { getRedirectUrl } from '../../config/auth';
+
+type SupabaseAuthMock = {
+  signInWithPassword: ReturnType<typeof vi.fn>;
+  signOut: ReturnType<typeof vi.fn>;
+  getSession: ReturnType<typeof vi.fn>;
+  getUser: ReturnType<typeof vi.fn>;
+  resetPasswordForEmail: ReturnType<typeof vi.fn>;
+  updateUser: ReturnType<typeof vi.fn>;
+};
+
+type SupabaseQueryBuilderMock = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+};
+
+type SupabaseMock = {
+  client: SupabaseClient;
+  auth: SupabaseAuthMock;
+  queryBuilder: SupabaseQueryBuilderMock;
+  from: ReturnType<typeof vi.fn>;
+};
+
+const createSupabaseMock = (): SupabaseMock => {
+  const queryBuilder: SupabaseQueryBuilderMock = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    single: vi.fn(),
+  };
+
+  queryBuilder.select.mockReturnValue(queryBuilder);
+  queryBuilder.eq.mockReturnValue(queryBuilder);
+
+  const auth: SupabaseAuthMock = {
+    signInWithPassword: vi.fn(),
+    signOut: vi.fn(),
+    getSession: vi.fn(),
+    getUser: vi.fn(),
+    resetPasswordForEmail: vi.fn(),
+    updateUser: vi.fn(),
+  };
+
+  const from = vi.fn().mockReturnValue(queryBuilder);
+
+  const client = {
+    auth,
+    from,
+  } as unknown as SupabaseClient;
+
+  return { client, auth, queryBuilder, from };
+};
+
+const createJsonResponse = (body: unknown, init?: ResponseInit): Response => {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers,
+  });
+};
+
+const createTextResponse = (text: string, init?: ResponseInit): Response => {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'text/plain');
+  }
+
+  return new Response(text, {
+    ...init,
+    headers,
+  });
+};
+
+describe('AuthService', () => {
+  let supabaseMock: SupabaseMock;
+
+  const buildService = (options: Partial<AuthServiceOptions> = {}) => {
+    return new AuthService({
+      supabaseClient: supabaseMock.client,
+      ...options,
+    });
+  };
+
+  beforeEach(() => {
+    supabaseMock = createSupabaseMock();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs in and returns the user session with profile', async () => {
+    const user = { id: 'user-1' } as User;
+    const session = { access_token: 'token' } as Session;
+    const profile: Profile = {
+      user_id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+    };
+
+    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+      data: { user, session },
+      error: null,
+    });
+
+    supabaseMock.queryBuilder.single.mockResolvedValue({ data: profile, error: null });
+
+    const service = buildService();
+    const result = await service.login({ email: '  user@example.com  ', password: 'password123' });
+
+    expect(supabaseMock.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'password123',
+    });
+    expect(result).toEqual({ user, profile, session });
+  });
+
+  it('returns a null profile when none exists for the user', async () => {
+    const user = { id: 'user-2' } as User;
+
+    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+      data: { user, session: null },
+      error: null,
+    });
+
+    const notFoundError = {
+      code: 'PGRST116',
+      message: 'JSON object requested, but no rows returned',
+    } as PostgrestError;
+
+    supabaseMock.queryBuilder.single.mockResolvedValue({ data: null, error: notFoundError });
+
+    const service = buildService();
+    const result = await service.login({ email: 'user@example.com', password: 'password123' });
+
+    expect(result.profile).toBeNull();
+  });
+
+  it('registers a user through the signup function then logs them in', async () => {
+    const user = { id: 'user-3' } as User;
+    const session = { access_token: 'token' } as Session;
+    const profile: Profile = {
+      user_id: 'user-3',
+      email: 'new@example.com',
+      name: 'New User',
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({ success: true }));
+
+    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+      data: { user, session },
+      error: null,
+    });
+
+    supabaseMock.queryBuilder.single.mockResolvedValue({ data: profile, error: null });
+
+    const service = buildService({
+      fetch: fetchMock,
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+
+    const result = await service.register({
+      email: ' new@example.com ',
+      password: 'password123',
+      name: '  New User ',
+      phone: ' 123456 ',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.supabase.co/functions/v1/signup');
+    expect(options?.method).toBe('POST');
+    expect(options?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer anon-key',
+    });
+    expect(JSON.parse(options?.body as string)).toEqual({
+      email: 'new@example.com',
+      password: 'password123',
+      name: 'New User',
+      phone: '123456',
+    });
+
+    expect(result).toEqual({ user, profile, session });
+  });
+
+  it('rejects registration attempts with weak passwords before calling the API', async () => {
+    const fetchMock = vi.fn();
+    const service = buildService({
+      fetch: fetchMock,
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+
+    await expect(
+      service.register({ email: 'user@example.com', password: 'short', name: 'User' })
+    ).rejects.toThrow('Le mot de passe doit contenir au moins 8 caractères');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(supabaseMock.auth.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it('propagates errors returned by the signup function', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse(
+        { success: false, error: 'Email already exists' },
+        { status: 400 }
+      )
+    );
+
+    const service = buildService({
+      fetch: fetchMock,
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+
+    await expect(
+      service.register({ email: 'user@example.com', password: 'password123', name: 'User' })
+    ).rejects.toThrow('Email already exists');
+
+    expect(supabaseMock.auth.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it('surfaces plain text errors returned by the signup function', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createTextResponse('Service indisponible', { status: 503 })
+    );
+
+    const service = buildService({
+      fetch: fetchMock,
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+
+    await expect(
+      service.register({ email: 'user@example.com', password: 'password123', name: 'User' })
+    ).rejects.toThrow('Service indisponible');
+
+    expect(supabaseMock.auth.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it('throws a friendly error when the signup endpoint is unreachable', async () => {
+    const networkError = new TypeError('Failed to fetch');
+    const fetchMock = vi.fn().mockRejectedValue(networkError);
+
+    const service = buildService({
+      fetch: fetchMock,
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+
+    await expect(
+      service.register({ email: 'user@example.com', password: 'password123', name: 'User' })
+    ).rejects.toMatchObject({
+      message: "Impossible de contacter le serveur d'inscription",
+      cause: networkError,
+    });
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Erreur d'inscription:",
+      expect.objectContaining({ message: "Impossible de contacter le serveur d'inscription" })
+    );
+    expect(supabaseMock.auth.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it('accepts successful signup responses without a JSON body', async () => {
+    const user = { id: 'user-5' } as User;
+    const session = { access_token: 'token' } as Session;
+    const profile: Profile = {
+      user_id: 'user-5',
+      email: 'nojson@example.com',
+      name: 'No Json',
+    };
+
+    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+      data: { user, session },
+      error: null,
+    });
+
+    supabaseMock.queryBuilder.single.mockResolvedValue({ data: profile, error: null });
+
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+
+    const service = buildService({
+      fetch: fetchMock,
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+
+    const result = await service.register({
+      email: 'nojson@example.com',
+      password: 'password123',
+      name: 'No Json',
+    });
+
+    expect(result).toEqual({ user, profile, session });
+  });
+
+  it('falls back to process.env when Vite env variables are blank', async () => {
+    const originalSupabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    const originalSupabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    const originalProcessUrl = process.env.SUPABASE_URL;
+    const originalProcessAnon = process.env.SUPABASE_ANON_KEY;
+
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
+
+    process.env.SUPABASE_URL = 'https://process.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'process-anon-key';
+
+    const user = { id: 'user-6' } as User;
+    const session = { access_token: 'token' } as Session;
+    const profile: Profile = {
+      user_id: 'user-6',
+      email: 'process@example.com',
+      name: 'Process User',
+    };
+
+    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+      data: { user, session },
+      error: null,
+    });
+    supabaseMock.queryBuilder.single.mockResolvedValue({ data: profile, error: null });
+
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({ success: true }));
+
+    const service = buildService({ fetch: fetchMock });
+
+    try {
+      await service.register({
+        email: 'process@example.com',
+        password: 'password123',
+        name: 'Process User',
+      });
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://process.supabase.co/functions/v1/signup');
+      expect(options?.headers).toMatchObject({ Authorization: 'Bearer process-anon-key' });
+    } finally {
+      vi.stubEnv('VITE_SUPABASE_URL', originalSupabaseUrl);
+      vi.stubEnv('VITE_SUPABASE_ANON_KEY', originalSupabaseAnonKey);
+
+      if (typeof originalProcessUrl === 'string') {
+        process.env.SUPABASE_URL = originalProcessUrl;
+      } else {
+        delete process.env.SUPABASE_URL;
+      }
+
+      if (typeof originalProcessAnon === 'string') {
+        process.env.SUPABASE_ANON_KEY = originalProcessAnon;
+      } else {
+        delete process.env.SUPABASE_ANON_KEY;
+      }
+    }
+  });
+
+  it('retrieves the current session from Supabase', async () => {
+    const session = { access_token: 'token' } as Session;
+    supabaseMock.auth.getSession.mockResolvedValue({ data: { session }, error: null });
+
+    const service = buildService();
+    const result = await service.getSession();
+
+    expect(result).toBe(session);
+  });
+
+  it('throws a fallback error when session retrieval fails', async () => {
+    const sessionError = new Error('Session unavailable');
+    supabaseMock.auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: sessionError,
+    });
+
+    const service = buildService();
+
+    await expect(service.getSession()).rejects.toMatchObject({
+      message: 'Échec de la récupération de la session',
+      cause: sessionError,
+    });
+  });
+
+  it('logs out the current user session', async () => {
+    supabaseMock.auth.signOut.mockResolvedValue({ error: null });
+
+    const service = buildService();
+    await service.logout();
+
+    expect(supabaseMock.auth.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a fallback error when logout fails', async () => {
+    const logoutError = new Error('Logout failed');
+    supabaseMock.auth.signOut.mockResolvedValue({ error: logoutError });
+
+    const service = buildService();
+
+    await expect(service.logout()).rejects.toMatchObject({
+      message: 'Échec de la déconnexion',
+      cause: logoutError,
+    });
+  });
+
+  it('returns null when no authenticated user is available for profile lookup', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const service = buildService();
+    const result = await service.getProfile();
+
+    expect(result).toBeNull();
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it('retrieves the current user profile when a session exists', async () => {
+    const user = { id: 'user-4' } as User;
+    const profile: Profile = {
+      user_id: 'user-4',
+      email: 'user4@example.com',
+      name: 'User 4',
+    };
+
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user }, error: null });
+    supabaseMock.queryBuilder.single.mockResolvedValue({ data: profile, error: null });
+
+    const service = buildService();
+    const result = await service.getProfile();
+
+    expect(result).toEqual(profile);
+  });
+
+  it('trims the email before requesting a password reset', async () => {
+    supabaseMock.auth.resetPasswordForEmail.mockResolvedValue({ error: null });
+
+    const service = buildService();
+    await service.resetPassword('  reset@example.com  ');
+
+    expect(supabaseMock.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'reset@example.com',
+      expect.objectContaining({ redirectTo: getRedirectUrl('PASSWORD_RESET') })
+    );
+  });
+
+  it('validates password strength before attempting an update', async () => {
+    const service = buildService();
+
+    await expect(service.updatePassword('short')).rejects.toThrow(
+      'Le mot de passe doit contenir au moins 8 caractères'
+    );
+
+    expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('updates the password when validation passes', async () => {
+    supabaseMock.auth.updateUser.mockResolvedValue({ error: null });
+
+    const service = buildService();
+    await service.updatePassword('password123');
+
+    expect(supabaseMock.auth.updateUser).toHaveBeenCalledWith({ password: 'password123' });
+  });
+});

--- a/src/services/__tests__/eventService.test.ts
+++ b/src/services/__tests__/eventService.test.ts
@@ -1,0 +1,220 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventService } from '../eventService';
+
+type QueryBuilder = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  ilike: ReturnType<typeof vi.fn>;
+  contains: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  then: ReturnType<typeof vi.fn>;
+  data: any;
+  error: any;
+};
+
+const createQueryBuilder = (): QueryBuilder => {
+  const builder: QueryBuilder = {
+    data: null,
+    error: null,
+    select: vi.fn(),
+    eq: vi.fn(),
+    ilike: vi.fn(),
+    contains: vi.fn(),
+    or: vi.fn(),
+    order: vi.fn(),
+    then: vi.fn(),
+  };
+
+  builder.select.mockReturnValue(builder);
+  builder.eq.mockReturnValue(builder);
+  builder.ilike.mockReturnValue(builder);
+  builder.contains.mockReturnValue(builder);
+  builder.or.mockReturnValue(builder);
+  builder.order.mockImplementation(() => Promise.resolve({ data: builder.data, error: builder.error }));
+  builder.then.mockImplementation((resolve) => Promise.resolve(resolve({ data: builder.data, error: builder.error })));
+
+  return builder;
+};
+
+interface SupabaseMock {
+  from: ReturnType<typeof vi.fn>;
+  channel: ReturnType<typeof vi.fn>;
+  builders: QueryBuilder[];
+  enqueueResponse: (response: { data: any; error: any }) => void;
+  client: SupabaseClient;
+}
+
+const createSupabaseMock = (): SupabaseMock => {
+  const builders: QueryBuilder[] = [];
+  const responseQueue: Array<{ data: any; error: any }> = [];
+
+  const from = vi.fn().mockImplementation(() => {
+    const builder = createQueryBuilder();
+    const response = responseQueue.shift() ?? { data: null, error: null };
+    builder.data = response.data;
+    builder.error = response.error;
+    builders.push(builder);
+    return builder;
+  });
+
+  const channel = vi.fn().mockImplementation(() => {
+    const subscription = {
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnValue({
+        unsubscribe: vi.fn().mockResolvedValue('ok'),
+      }),
+    };
+    return subscription;
+  });
+
+  const enqueueResponse = (response: { data: any; error: any }) => {
+    responseQueue.push(response);
+  };
+
+  return {
+    from,
+    channel,
+    builders,
+    enqueueResponse,
+    client: { from, channel } as unknown as SupabaseClient,
+  };
+};
+
+describe('EventService', () => {
+  const logger = { error: vi.fn(), warn: vi.fn() };
+  let supabaseMock: SupabaseMock;
+  let service: EventService;
+
+  beforeEach(() => {
+    supabaseMock = createSupabaseMock();
+    service = new EventService({ supabaseClient: supabaseMock.client, logger });
+    logger.error.mockReset();
+    logger.warn.mockReset();
+  });
+
+  it('fetches published events and normalises tickets and categories', async () => {
+    supabaseMock.enqueueResponse({
+      data: [
+        {
+          id: 'event-1',
+          title: 'Event One',
+          featured: true,
+          categories: ['Music', '  Music  '],
+          ticket_types: [
+            { id: 'ticket-1', event_id: 'event-1', name: 'VIP', description: '', price: 100, quantity: 10, available: 10, max_per_order: 2 },
+            null,
+          ],
+        },
+        {
+          id: 'event-2',
+          title: 'Event Two',
+          featured: false,
+          categories: [],
+          ticket_types: null,
+        },
+      ],
+      error: null,
+    });
+
+    const events = await service.fetchPublishedEvents({ search: 'Concert%', location: 'Paris', category: 'Music' });
+
+    expect(supabaseMock.builders).toHaveLength(1);
+    const builder = supabaseMock.builders[0];
+    expect(builder.select).toHaveBeenCalled();
+    expect(builder.eq).toHaveBeenCalledWith('status', 'PUBLISHED');
+    expect(builder.or).toHaveBeenCalledWith('title.ilike.%Concert\\%%,description.ilike.%Concert\\%%');
+    expect(builder.ilike).toHaveBeenCalledWith('location', '%Paris%');
+    expect(builder.contains).toHaveBeenCalledWith('categories', ['Music']);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        id: 'event-1',
+        featured: true,
+        categories: ['Music'],
+        ticket_types: [
+          expect.objectContaining({ id: 'ticket-1' }),
+        ],
+      }),
+      expect.objectContaining({
+        id: 'event-2',
+        categories: undefined,
+        ticket_types: [],
+      }),
+    ]);
+  });
+
+  it('sanitises filter values before querying Supabase', async () => {
+    supabaseMock.enqueueResponse({ data: [], error: null });
+
+    await service.fetchPublishedEvents({
+      search: '  Concert%,)DROP TABLE  ',
+      location: '  %Paris_\\  ',
+      category: '  Music  ',
+      date: '2024-06-01',
+    });
+
+    const builder = supabaseMock.builders[0];
+    expect(builder.or).toHaveBeenCalledWith(
+      'title.ilike.%Concert\\% DROP TABLE%,description.ilike.%Concert\\% DROP TABLE%',
+    );
+    expect(builder.ilike).toHaveBeenCalledWith('location', '%\\%Paris\\_\\\\%');
+    expect(builder.contains).toHaveBeenCalledWith('categories', ['Music']);
+    expect(builder.eq).toHaveBeenCalledWith('date', '2024-06-01');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('ignores invalid date filters and logs a warning', async () => {
+    supabaseMock.enqueueResponse({ data: [], error: null });
+
+    await service.fetchPublishedEvents({ date: 'not-a-date' });
+
+    const builder = supabaseMock.builders[0];
+    expect(builder.eq).not.toHaveBeenCalledWith('date', expect.anything());
+    expect(logger.warn).toHaveBeenCalledWith('Ignoring invalid date filter', { date: 'not-a-date' });
+  });
+
+  it('throws a user friendly error when the query fails', async () => {
+    const failure = { message: 'database error' };
+    supabaseMock.enqueueResponse({ data: null, error: failure });
+
+    await expect(service.fetchPublishedEvents()).rejects.toThrow('Failed to load events');
+    expect(logger.error).toHaveBeenCalledWith('Failed to fetch events:', failure);
+  });
+
+  it('returns distinct locations and categories for filters', async () => {
+    supabaseMock.enqueueResponse({
+      data: [
+        { location: ' Paris ', categories: ['Music', 'Art'] },
+        { location: 'Abidjan', categories: ['Music', 'Tech', 'Music'] },
+        { location: 'Paris', categories: [null, 'Tech', '  Art  '] },
+      ],
+      error: null,
+    });
+
+    const metadata = await service.fetchFilterMetadata();
+    expect(metadata.locations).toEqual(['Abidjan', 'Paris']);
+    expect(metadata.categories).toEqual(['Art', 'Music', 'Tech']);
+  });
+
+  it('throws when fetching filter metadata fails', async () => {
+    const failure = { message: 'timeout' };
+    supabaseMock.enqueueResponse({ data: null, error: failure });
+
+    await expect(service.fetchFilterMetadata()).rejects.toThrow('Failed to load event filters');
+    expect(logger.error).toHaveBeenCalledWith('Failed to fetch event filter metadata:', failure);
+  });
+
+  it('subscribes to realtime changes and returns the channel', () => {
+    const handler = vi.fn();
+    const channel = service.subscribeToEventChanges(handler);
+
+    expect(supabaseMock.channel).toHaveBeenCalledWith('events_channel');
+    const subscription = supabaseMock.channel.mock.results[0].value;
+    expect(subscription.on).toHaveBeenCalled();
+    expect(subscription.subscribe).toHaveBeenCalled();
+    expect(channel).toBe(subscription.subscribe.mock.results[0].value);
+  });
+});
+

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,0 +1,106 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { NotificationService } from '../notificationService';
+
+const createLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+});
+
+describe('NotificationService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches notifications scoped to the authenticated user with a sane limit', async () => {
+    const notificationsBuilder: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [{ id: 'notif-1' }], error: null }),
+    };
+
+    const auth = {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    };
+
+    const from = vi.fn((table: string) => {
+      if (table === 'notifications') {
+        return notificationsBuilder;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const supabaseMock = { auth, from } as unknown as SupabaseClient;
+    const logger = createLogger();
+    const service = new NotificationService({ supabaseClient: supabaseMock, logger });
+
+    const notifications = await service.getUserNotifications(-5);
+
+    expect(auth.getUser).toHaveBeenCalledTimes(1);
+    expect(notificationsBuilder.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(notificationsBuilder.limit).toHaveBeenCalledWith(10);
+    expect(notifications).toEqual([{ id: 'notif-1' }]);
+  });
+
+  it('marks a notification as read while enforcing ownership', async () => {
+    const notificationsBuilder: any = {};
+    notificationsBuilder.update = vi.fn().mockReturnValue(notificationsBuilder);
+    notificationsBuilder.eq = vi.fn().mockReturnThis();
+    notificationsBuilder.select = vi.fn().mockResolvedValue({ data: [{ id: 'notif-1' }], error: null });
+
+    const auth = {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    };
+
+    const from = vi.fn((table: string) => {
+      if (table === 'notifications') {
+        return notificationsBuilder;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const supabaseMock = { auth, from } as unknown as SupabaseClient;
+    const logger = createLogger();
+    const service = new NotificationService({ supabaseClient: supabaseMock, logger });
+
+    await expect(service.markAsRead('notif-1')).resolves.toBe(true);
+
+    expect(notificationsBuilder.update).toHaveBeenCalledWith({
+      read: 'true',
+      read_at: expect.any(String),
+    });
+    expect(notificationsBuilder.eq).toHaveBeenNthCalledWith(1, 'id', 'notif-1');
+    expect(notificationsBuilder.eq).toHaveBeenNthCalledWith(2, 'user_id', 'user-1');
+    expect(notificationsBuilder.select).toHaveBeenCalledWith('id');
+  });
+
+  it('deletes a notification scoped to the authenticated user', async () => {
+    const deleteByUser = vi.fn().mockResolvedValue({ error: null, count: 1 });
+    const deleteById = vi.fn().mockReturnValue({ eq: deleteByUser });
+    const notificationsBuilder: any = {
+      delete: vi.fn().mockReturnValue({ eq: deleteById }),
+    };
+
+    const auth = {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    };
+
+    const from = vi.fn((table: string) => {
+      if (table === 'notifications') {
+        return notificationsBuilder;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const supabaseMock = { auth, from } as unknown as SupabaseClient;
+    const logger = createLogger();
+    const service = new NotificationService({ supabaseClient: supabaseMock, logger });
+
+    await expect(service.deleteNotification('notif-1')).resolves.toBeUndefined();
+
+    expect(notificationsBuilder.delete).toHaveBeenCalledWith({ count: 'exact' });
+    expect(deleteById).toHaveBeenCalledWith('id', 'notif-1');
+    expect(deleteByUser).toHaveBeenCalledWith('user_id', 'user-1');
+  });
+});

--- a/src/services/__tests__/orderService.test.ts
+++ b/src/services/__tests__/orderService.test.ts
@@ -1,0 +1,231 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { OrderService } from '../orderService';
+
+type SupabaseAuthMock = {
+  getUser: ReturnType<typeof vi.fn>;
+};
+
+type SupabaseFromMock = ReturnType<typeof vi.fn>;
+
+type SupabaseRpcMock = ReturnType<typeof vi.fn>;
+
+interface SupabaseMock {
+  supabase: SupabaseClient;
+  auth: SupabaseAuthMock;
+  from: SupabaseFromMock;
+  rpc: SupabaseRpcMock;
+  ticketIn: ReturnType<typeof vi.fn>;
+  ordersInsert: ReturnType<typeof vi.fn>;
+  ordersDeleteEq: ReturnType<typeof vi.fn>;
+}
+
+const createSupabaseMock = (): SupabaseMock => {
+  const auth = {
+    getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+  };
+
+  const profileSingle = vi.fn().mockResolvedValue({
+    data: { name: 'User', email: 'user@example.com', phone: '  +229 123 456 ' },
+    error: null,
+  });
+
+  const profilesQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: profileSingle,
+  };
+
+  const ticketIn = vi.fn().mockResolvedValue({
+    data: [
+      { id: 'ticket-1', price: 100, event_id: 'event-1' },
+      { id: 'ticket-2', price: 50, event_id: 'event-1' },
+    ],
+    error: null,
+  });
+
+  const ticketQuery = {
+    select: vi.fn().mockReturnThis(),
+    in: ticketIn,
+  };
+
+  const eventSingle = vi.fn().mockResolvedValue({
+    data: { title: 'Event', currency: 'XOF', status: 'PUBLISHED' },
+    error: null,
+  });
+
+  const eventsQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: eventSingle,
+  };
+
+  const orderSingle = vi.fn().mockResolvedValue({ data: { id: 'order-1' }, error: null });
+  const orderSelectBuilder = {
+    single: orderSingle,
+  };
+
+  const ordersInsert = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue(orderSelectBuilder),
+    single: orderSingle,
+  });
+
+  const ordersDeleteEq = vi.fn().mockResolvedValue({ error: null });
+  const ordersDelete = vi.fn().mockReturnValue({ eq: ordersDeleteEq });
+
+  const ordersBuilder = {
+    insert: ordersInsert,
+    delete: ordersDelete,
+  };
+
+  const from = vi.fn((table: string) => {
+    switch (table) {
+      case 'profiles':
+        return profilesQuery;
+      case 'ticket_types':
+        return ticketQuery;
+      case 'events':
+        return eventsQuery;
+      case 'orders':
+        return ordersBuilder;
+      default:
+        throw new Error(`Unexpected table ${table}`);
+    }
+  });
+
+  const rpc = vi.fn();
+
+  return {
+    supabase: { auth, from, rpc } as unknown as SupabaseClient,
+    auth,
+    from,
+    rpc,
+    ticketIn,
+    ordersInsert,
+    ordersDeleteEq,
+  };
+};
+
+describe('OrderService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('creates an order and forwards sanitized payment data', async () => {
+    const supabaseMock = createSupabaseMock();
+    const paymentClient = {
+      createPayment: vi.fn().mockResolvedValue({
+        success: true,
+        payment_url: 'https://pay.example',
+        payment_token: 'token-123',
+      }),
+    };
+
+    vi.stubGlobal('window', { location: { origin: 'https://app.example' } } as unknown as Window);
+    vi.stubGlobal('location', { origin: 'https://app.example' } as unknown as Location);
+
+    const service = new OrderService({
+      supabaseClient: supabaseMock.supabase,
+      paymentClient,
+    });
+
+    const result = await service.createOrder({
+      eventId: 'event-1',
+      ticketQuantities: { 'ticket-1': 2, 'ticket-2': 0 },
+      paymentMethod: 'MOBILE_MONEY',
+      paymentDetails: { provider: ' Orange ', phone: ' +229 123 456 ' },
+    });
+
+    expect(result).toEqual({
+      orderId: 'order-1',
+      paymentUrl: 'https://pay.example',
+      paymentToken: 'token-123',
+      success: true,
+    });
+
+    expect(paymentClient.createPayment).toHaveBeenCalledTimes(1);
+    const paymentRequest = paymentClient.createPayment.mock.calls[0][0];
+    expect(paymentRequest.phone).toBe('+229123456');
+    expect(paymentRequest.provider).toBe('orange');
+    expect(paymentRequest.ticket_lines).toEqual([
+      {
+        ticket_type_id: 'ticket-1',
+        quantity: 2,
+        price_major: 100,
+        currency: 'XOF',
+      },
+    ]);
+    expect(paymentRequest.return_url).toBe('https://app.example/payment/success');
+
+    expect(supabaseMock.ordersInsert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      event_id: 'event-1',
+      total: 200,
+      status: 'PENDING',
+      payment_method: 'MOBILE_MONEY',
+      ticket_quantities: { 'ticket-1': 2 },
+    });
+  });
+
+  it('rejects ticket types that do not belong to the event', async () => {
+    const supabaseMock = createSupabaseMock();
+    supabaseMock.ticketIn.mockResolvedValue({
+      data: [{ id: 'ticket-1', price: 100, event_id: 'other-event' }],
+      error: null,
+    });
+
+    const paymentClient = { createPayment: vi.fn() };
+    const service = new OrderService({
+      supabaseClient: supabaseMock.supabase,
+      paymentClient,
+    });
+
+    await expect(service.createOrder({
+      eventId: 'event-1',
+      ticketQuantities: { 'ticket-1': 1 },
+      paymentMethod: 'MOBILE_MONEY',
+      paymentDetails: { provider: 'orange', phone: '0700000000' },
+    })).rejects.toThrow('Certains billets ne correspondent pas à cet événement');
+  });
+
+  it('rolls back the order when payment creation fails', async () => {
+    const supabaseMock = createSupabaseMock();
+    const paymentClient = {
+      createPayment: vi.fn().mockRejectedValue(new Error('payment down')),
+    };
+
+    vi.stubGlobal('window', { location: { origin: 'https://app.example' } } as unknown as Window);
+    vi.stubGlobal('location', { origin: 'https://app.example' } as unknown as Location);
+
+    const service = new OrderService({
+      supabaseClient: supabaseMock.supabase,
+      paymentClient,
+    });
+
+    await expect(service.createOrder({
+      eventId: 'event-1',
+      ticketQuantities: { 'ticket-1': 1 },
+      paymentMethod: 'MOBILE_MONEY',
+      paymentDetails: { provider: 'orange', phone: '0700000000' },
+    })).rejects.toThrow('payment down');
+
+    expect(supabaseMock.ordersDeleteEq).toHaveBeenCalledWith('id', 'order-1');
+  });
+
+  it('rejects negative ticket quantities', async () => {
+    const supabaseMock = createSupabaseMock();
+    const paymentClient = { createPayment: vi.fn() };
+    const service = new OrderService({
+      supabaseClient: supabaseMock.supabase,
+      paymentClient,
+    });
+
+    await expect(service.createOrder({
+      eventId: 'event-1',
+      ticketQuantities: { 'ticket-1': -1 },
+      paymentMethod: 'MOBILE_MONEY',
+      paymentDetails: { provider: 'orange', phone: '0700000000' },
+    })).rejects.toThrow('La quantité de billets ne peut pas être négative');
+  });
+});

--- a/src/services/__tests__/paymentService.test.ts
+++ b/src/services/__tests__/paymentService.test.ts
@@ -1,0 +1,159 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PaymentService, type CreatePaymentRequest } from '../paymentService';
+import { paymentMethodService } from '../paymentMethodService';
+import { notificationTriggers } from '../notificationTriggers';
+
+const ORIGINAL_ENV_URL = process.env.VITE_SUPABASE_URL;
+const ORIGINAL_ENV_KEY = process.env.VITE_SUPABASE_ANON_KEY;
+
+const createLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+});
+
+describe('PaymentService', () => {
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.VITE_SUPABASE_ANON_KEY = 'anon-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.VITE_SUPABASE_URL = ORIGINAL_ENV_URL;
+    process.env.VITE_SUPABASE_ANON_KEY = ORIGINAL_ENV_KEY;
+  });
+
+  const baseRequest: CreatePaymentRequest = {
+    idempotency_key: 'key-1',
+    event_id: 'event-1',
+    ticket_lines: [
+      { ticket_type_id: 'ticket-1', quantity: 2, price_major: 1000, currency: 'XOF' },
+    ],
+    amount_major: 2000,
+    currency: 'XOF',
+    method: 'mobile_money',
+    description: 'Tickets',
+  };
+
+  const createSupabaseMock = (): SupabaseClient => {
+    const auth = {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    };
+
+    const functions = {
+      invoke: vi.fn(),
+    };
+
+    const from = vi.fn();
+
+    return { auth, functions, from } as unknown as SupabaseClient;
+  };
+
+  it('sends the payment request to the Supabase function and returns the provider response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ success: true, payment_url: 'https://pay.example', payment_token: 'token-123', payment_id: 'pid-1' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    const service = new PaymentService({
+      supabaseClient: createSupabaseMock(),
+      fetch: fetchMock,
+      logger: createLogger(),
+    });
+
+    const response = await service.createPayment(baseRequest);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.supabase.co/functions/v1/create-payment',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(response).toEqual({
+      success: true,
+      payment_url: 'https://pay.example',
+      payment_token: 'token-123',
+      payment_id: 'pid-1',
+    });
+  });
+
+  it('throws a descriptive error when the payment function responds with failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: 'invalid request' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    const service = new PaymentService({
+      supabaseClient: createSupabaseMock(),
+      fetch: fetchMock,
+      logger: createLogger(),
+    });
+
+    await expect(service.createPayment(baseRequest)).rejects.toThrow('Échec de la création du paiement: invalid request');
+  });
+
+  it('verifies payments, saves masked card details, and triggers notifications', async () => {
+    const supabaseMock = createSupabaseMock();
+    const ordersBuilder: any = {};
+    ordersBuilder.select = vi.fn().mockReturnValue(ordersBuilder);
+    ordersBuilder.eq = vi.fn().mockReturnValue(ordersBuilder);
+    ordersBuilder.single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'order-1',
+        user_id: 'user-1',
+        total: 2000,
+        currency: 'XOF',
+        events: { title: 'Concert' },
+        order_items: [{ quantity: 2 }],
+      },
+      error: null,
+    });
+
+    (supabaseMock.functions as any).invoke = vi.fn().mockResolvedValue({
+      data: { success: true, status: 'completed', payment_id: 'pid-1', order_id: 'order-1', message: 'done' },
+      error: null,
+    });
+
+    (supabaseMock.from as any) = vi.fn().mockImplementation((table: string) => {
+      if (table === 'orders') {
+        return ordersBuilder;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const paymentMethodSpy = vi.spyOn(paymentMethodService, 'savePaymentMethod').mockResolvedValue(undefined as any);
+    const notificationSpy = vi.spyOn(notificationTriggers, 'onOrderCreated').mockResolvedValue();
+
+    const service = new PaymentService({
+      supabaseClient: supabaseMock,
+      fetch: vi.fn(),
+      logger: createLogger(),
+    });
+
+    const result = await service.verifyPayment('4111111111111111', 'order-1', true, {
+      method: 'credit_card',
+      cardNumber: '4111 1111 1111 1111',
+      cardholderName: 'Tester',
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: 'completed',
+      payment_id: 'pid-1',
+      order_id: 'order-1',
+    });
+
+    expect(paymentMethodSpy).toHaveBeenCalledWith({
+      method_type: 'credit_card',
+      provider: 'Visa',
+      account_number: '****1111',
+      account_name: 'Tester',
+      is_default: false,
+    });
+
+    expect(notificationSpy).toHaveBeenCalledWith(expect.objectContaining({
+      order_id: 'order-1',
+      user_id: 'user-1',
+      ticket_count: 2,
+    }));
+  });
+});

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,4 @@
-// src/services/authService.ts
+import type { PostgrestError, Session, SupabaseClient, User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase-client';
 import { getRedirectUrl, validatePassword } from '../config/auth';
 
@@ -14,146 +14,427 @@ interface RegisterData {
   phone?: string;
 }
 
-class AuthService {
-  async login(credentials: LoginCredentials) {
+interface SignupFunctionResponse {
+  success: boolean;
+  error?: string;
+}
+
+export interface Profile {
+  id?: string;
+  user_id: string;
+  email: string;
+  name: string;
+  phone?: string | null;
+  role?: string | null;
+  avatar_url?: string | null;
+  bio?: string | null;
+  location?: string | null;
+  [key: string]: unknown;
+}
+
+type AuthSuccessResponse = {
+  user: User;
+  profile: Profile | null;
+  session: Session | null;
+};
+
+export interface AuthServiceOptions {
+  supabaseClient?: SupabaseClient;
+  fetch?: typeof fetch;
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+}
+
+export class AuthService {
+  private readonly client: SupabaseClient;
+  private readonly fetchImpl: typeof fetch;
+  private readonly configuredSupabaseUrl?: string;
+  private readonly configuredSupabaseAnonKey?: string;
+
+  constructor(options: AuthServiceOptions = {}) {
+    this.client = options.supabaseClient ?? supabase;
+
+    if (options.fetch) {
+      this.fetchImpl = options.fetch;
+    } else if (typeof fetch === 'function') {
+      this.fetchImpl = fetch;
+    } else {
+      throw new Error('Fetch API is not available in the current environment.');
+    }
+
+    this.configuredSupabaseUrl = options.supabaseUrl ?? undefined;
+    this.configuredSupabaseAnonKey = options.supabaseAnonKey ?? undefined;
+  }
+
+  async login(credentials: LoginCredentials): Promise<AuthSuccessResponse> {
+    const email = credentials.email?.trim();
+    const password = credentials.password;
+
+    if (!email) {
+      throw new Error('Adresse e-mail requise');
+    }
+
+    if (!password) {
+      throw new Error('Le mot de passe est requis');
+    }
+
     try {
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email: credentials.email,
-        password: credentials.password
+      const { data, error } = await this.client.auth.signInWithPassword({
+        email,
+        password,
       });
 
-      if (error) throw error;
+      if (error) {
+        throw error;
+      }
 
-      // Get user profile after successful login
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('user_id', data.user.id)
-        .single();
+      if (!data?.user) {
+        throw new Error('Utilisateur introuvable après la connexion');
+      }
+
+      const profile = await this.fetchProfile(data.user.id);
 
       return {
         user: data.user,
         profile,
-        session: data.session
+        session: data.session ?? null,
       };
-    } catch (error: any) {
-      console.error('Erreur de connexion:', error);
-      throw new Error(error.message || 'Échec de la connexion');
+    } catch (error) {
+      this.handleError(error, 'Échec de la connexion', 'Erreur de connexion:');
     }
   }
 
-  async register(data: RegisterData) {
-    try {
-      // Use the custom signup edge function
-      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-      const response = await fetch(`${supabaseUrl}/functions/v1/signup`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
-        },
-        body: JSON.stringify({
-          email: data.email,
-          password: data.password,
-          name: data.name,
-          phone: data.phone
-        })
-      });
+  async register(data: RegisterData): Promise<AuthSuccessResponse> {
+    const email = data.email?.trim();
+    const password = data.password;
+    const name = data.name?.trim();
+    const phone = data.phone?.trim();
 
-      const result = await response.json();
+    if (!email) {
+      throw new Error('Adresse e-mail requise');
+    }
+
+    if (!password) {
+      throw new Error('Le mot de passe est requis');
+    }
+
+    if (!name) {
+      throw new Error('Le nom est requis');
+    }
+
+    const validation = validatePassword(password);
+    if (!validation.isValid) {
+      throw new Error(validation.errors.join(', '));
+    }
+
+    try {
+      const { supabaseUrl, supabaseAnonKey } = this.resolveSignupConfig();
+
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${supabaseUrl}/functions/v1/signup`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${supabaseAnonKey}`,
+          },
+          body: JSON.stringify({
+            email,
+            password,
+            name,
+            ...(phone ? { phone } : {}),
+          }),
+        });
+      } catch (networkError) {
+        throw this.normalizeError(
+          networkError,
+          'Impossible de contacter le serveur d\'inscription',
+          true
+        );
+      }
+
+      const result = await this.safeJsonParse<SignupFunctionResponse>(response);
+
+      if (!response.ok) {
+        const message =
+          result?.error ||
+          (await this.safeReadText(response)) ||
+          `Échec de la création du compte (code ${response.status})`;
+        throw new Error(message);
+      }
+
+      if (!result) {
+        if (response.status === 204) {
+          return await this.login({ email, password });
+        }
+
+        throw new Error('Réponse invalide du serveur d\'inscription');
+      }
 
       if (!result.success) {
         throw new Error(result.error || 'Échec de la création du compte');
       }
 
-      // Sign in the user after successful registration
-      const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
-        email: data.email,
-        password: data.password
-      });
-
-      if (signInError) throw signInError;
-
-      // Get user profile
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('user_id', signInData.user.id)
-        .single();
-
-      return {
-        user: signInData.user,
-        profile,
-        session: signInData.session
-      };
-    } catch (error: any) {
-      console.error('Erreur d\'inscription:', error);
-      throw new Error(error.message || 'Échec de la création du compte');
+      return await this.login({ email, password });
+    } catch (error) {
+      this.handleError(error, 'Échec de la création du compte', 'Erreur d\'inscription:');
     }
   }
 
-  async logout() {
-    const { error } = await supabase.auth.signOut();
-    if (error) throw error;
+  async logout(): Promise<void> {
+    try {
+      const { error } = await this.client.auth.signOut();
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      this.handleError(error, 'Échec de la déconnexion', 'Erreur de déconnexion:', {
+        preferFallbackMessage: true,
+      });
+    }
   }
 
-  async getSession() {
-    const { data: { session }, error } = await supabase.auth.getSession();
-    if (error) throw error;
-    return session;
+  async getSession(): Promise<Session | null> {
+    try {
+      const { data: { session }, error } = await this.client.auth.getSession();
+      if (error) {
+        throw error;
+      }
+      return session ?? null;
+    } catch (error) {
+      this.handleError(error, 'Échec de la récupération de la session', 'Erreur de récupération de la session:', {
+        preferFallbackMessage: true,
+      });
+    }
   }
 
-  async getProfile() {
-    const { data: { user }, error: userError } = await supabase.auth.getUser();
-    if (userError) throw userError;
-    if (!user) return null;
+  async getProfile(): Promise<Profile | null> {
+    try {
+      const { data: { user }, error } = await this.client.auth.getUser();
+      if (error) {
+        throw error;
+      }
 
-    const { data: profile, error: profileError } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('user_id', user.id)
-      .single();
+      if (!user) {
+        return null;
+      }
 
-    if (profileError) throw profileError;
-    return profile;
+      return await this.fetchProfile(user.id);
+    } catch (error) {
+      this.handleError(error, 'Échec de la récupération du profil', 'Erreur de récupération du profil:');
+    }
   }
 
-  async resetPassword(email: string) {
+  async resetPassword(email: string): Promise<{ success: true }> {
+    const normalizedEmail = email?.trim();
+    if (!normalizedEmail) {
+      throw new Error('Adresse e-mail requise');
+    }
+
     try {
       const redirectUrl = getRedirectUrl('PASSWORD_RESET');
-      
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      const { error } = await this.client.auth.resetPasswordForEmail(normalizedEmail, {
         redirectTo: redirectUrl,
       });
 
-      if (error) throw error;
-      
+      if (error) {
+        throw error;
+      }
+
       return { success: true };
-    } catch (error: any) {
-      console.error('Erreur de réinitialisation du mot de passe:', error);
-      throw new Error(error.message || 'Échec de l\'envoi des instructions de réinitialisation');
+    } catch (error) {
+      this.handleError(
+        error,
+        'Échec de l\'envoi des instructions de réinitialisation',
+        'Erreur de réinitialisation du mot de passe:'
+      );
     }
   }
 
-  async updatePassword(newPassword: string) {
-    try {
-      // Validate password strength
-      const validation = validatePassword(newPassword);
-      if (!validation.isValid) {
-        throw new Error(validation.errors.join(', '));
-      }
+  async updatePassword(newPassword: string): Promise<{ success: true }> {
+    const validation = validatePassword(newPassword);
+    if (!validation.isValid) {
+      throw new Error(validation.errors.join(', '));
+    }
 
-      const { error } = await supabase.auth.updateUser({
-        password: newPassword
+    try {
+      const { error } = await this.client.auth.updateUser({
+        password: newPassword,
       });
 
-      if (error) throw error;
-      
+      if (error) {
+        throw error;
+      }
+
       return { success: true };
-    } catch (error: any) {
-      console.error('Erreur de mise à jour du mot de passe:', error);
-      throw new Error(error.message || 'Échec de la mise à jour du mot de passe');
+    } catch (error) {
+      this.handleError(error, 'Échec de la mise à jour du mot de passe', 'Erreur de mise à jour du mot de passe:');
     }
+  }
+
+  private async fetchProfile(userId: string): Promise<Profile | null> {
+    const { data, error } = await this.client
+      .from('profiles')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      if (this.isRecordNotFound(error)) {
+        return null;
+      }
+
+      throw error;
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    return data as Profile;
+  }
+
+  private resolveSignupConfig(): { supabaseUrl: string; supabaseAnonKey: string } {
+    const envSupabaseUrl =
+      this.configuredSupabaseUrl ??
+      this.getEnvValue('VITE_SUPABASE_URL', 'SUPABASE_URL');
+    const envSupabaseAnonKey =
+      this.configuredSupabaseAnonKey ??
+      this.getEnvValue('VITE_SUPABASE_ANON_KEY', 'SUPABASE_ANON_KEY');
+
+    const supabaseUrl = typeof envSupabaseUrl === 'string' ? envSupabaseUrl.trim().replace(/\/$/, '') : '';
+    const supabaseAnonKey = typeof envSupabaseAnonKey === 'string' ? envSupabaseAnonKey.trim() : '';
+
+    if (!supabaseUrl) {
+      throw new Error('Configuration Supabase manquante (URL).');
+    }
+
+    if (!supabaseAnonKey) {
+      throw new Error('Configuration Supabase manquante (clé Anon).');
+    }
+
+    return { supabaseUrl, supabaseAnonKey };
+  }
+
+  private async safeJsonParse<T>(response: Response): Promise<T | null> {
+    const target = typeof response.clone === 'function' ? response.clone() : response;
+    const contentType = target.headers?.get?.('content-type');
+    if (!contentType || !contentType.toLowerCase().includes('application/json')) {
+      return null;
+    }
+
+    try {
+      return (await target.json()) as T;
+    } catch (error) {
+      console.warn('Impossible d\'analyser la réponse JSON de la fonction signup:', error);
+      return null;
+    }
+  }
+
+  private async safeReadText(response: Response): Promise<string | null> {
+    const target = typeof response.clone === 'function' ? response.clone() : response;
+
+    if (typeof target.text !== 'function') {
+      return null;
+    }
+
+    try {
+      const text = await target.text();
+      const trimmed = text.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    } catch (error) {
+      console.warn('Impossible de lire la réponse textuelle de la fonction signup:', error);
+      return null;
+    }
+  }
+
+  private getEnvValue(...keys: string[]): string | undefined {
+    for (const key of keys) {
+      const fromImportMeta = this.readFromImportMeta(key);
+      if (fromImportMeta) {
+        return fromImportMeta;
+      }
+
+      const fromProcessEnv = this.readFromProcessEnv(key);
+      if (fromProcessEnv) {
+        return fromProcessEnv;
+      }
+    }
+
+    return undefined;
+  }
+
+  private readFromImportMeta(key: string): string | undefined {
+    try {
+      const meta = import.meta as ImportMeta & { env?: Record<string, unknown> };
+      const env = meta?.env;
+      const value = env?.[key as keyof ImportMetaEnv] ?? (env?.[key] as string | undefined);
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.length > 0) {
+          return trimmed;
+        }
+      }
+    } catch {
+      // Ignored: import.meta may not be available in all runtimes (e.g. SSR tests)
+    }
+
+    return undefined;
+  }
+
+  private readFromProcessEnv(key: string): string | undefined {
+    if (typeof process === 'undefined' || typeof process.env !== 'object' || process.env === null) {
+      return undefined;
+    }
+
+    const env = process.env as Record<string, string | undefined>;
+    const value = env[key];
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+
+    return undefined;
+  }
+
+  private normalizeError(error: unknown, fallbackMessage: string, preferFallbackMessage = false): Error {
+    if (!preferFallbackMessage) {
+      if (error instanceof Error) {
+        const message = typeof error.message === 'string' ? error.message.trim() : '';
+        if (message) {
+          return error;
+        }
+      }
+
+      if (typeof error === 'string') {
+        const trimmed = error.trim();
+        if (trimmed) {
+          return new Error(trimmed);
+        }
+      }
+    }
+
+    return new Error(fallbackMessage, { cause: error });
+  }
+
+  private isRecordNotFound(error: PostgrestError): boolean {
+    return error.code === 'PGRST116'
+      || error.message === 'JSON object requested, but no rows returned'
+      || (typeof error.details === 'string' && error.details.includes('Results contain 0 rows'));
+  }
+
+  private handleError(
+    error: unknown,
+    fallbackMessage: string,
+    context: string,
+    options: { preferFallbackMessage?: boolean } = {}
+  ): never {
+    console.error(context, error);
+
+    const { preferFallbackMessage = false } = options;
+    throw this.normalizeError(error, fallbackMessage, preferFallbackMessage);
   }
 }
 

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,0 +1,226 @@
+import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase-client';
+import type { Event, TicketType } from '../types/event';
+
+type EventRow = Event & {
+  ticket_types: (TicketType | null)[] | null;
+  categories: string[] | null;
+};
+
+type EventFilterRow = Pick<Event, 'location' | 'categories'>;
+
+export interface EventServiceFilters {
+  search?: string;
+  location?: string;
+  date?: string;
+  category?: string;
+}
+
+export interface EventServiceOptions {
+  supabaseClient?: SupabaseClient;
+  logger?: Pick<Console, 'error' | 'warn'>;
+}
+
+const SEARCH_TERM_MAX_LENGTH = 120;
+const LOCATION_TERM_MAX_LENGTH = 80;
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/g;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+const escapePatternOperators = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/[%_]/g, match => `\\${match}`);
+
+const collapseWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const sanitizePatternTerm = (
+  raw: string,
+  { limit, stripGroupingTokens }: { limit: number; stripGroupingTokens?: boolean },
+): string => {
+  const truncated = raw.slice(0, limit);
+  const normalised = truncated
+    .normalize('NFKC')
+    .replace(CONTROL_CHARACTERS, ' ');
+  const withoutGrouping = stripGroupingTokens
+    ? normalised.replace(/[(),]/g, ' ')
+    : normalised;
+  const collapsed = collapseWhitespace(withoutGrouping);
+  if (!collapsed) {
+    return '';
+  }
+  return escapePatternOperators(collapsed);
+};
+
+const sanitizeSearchTerm = (raw: string): string =>
+  sanitizePatternTerm(raw, { limit: SEARCH_TERM_MAX_LENGTH, stripGroupingTokens: true });
+
+const sanitizeLocationTerm = (raw: string): string =>
+  sanitizePatternTerm(raw, { limit: LOCATION_TERM_MAX_LENGTH });
+
+const sanitiseFilterLabel = (value: string | null | undefined): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalised = collapseWhitespace(value.normalize('NFKC').replace(CONTROL_CHARACTERS, ' '));
+  return normalised || null;
+};
+
+const normaliseCategoryList = (categories: string[] | null | undefined): string[] | undefined => {
+  if (!categories) {
+    return undefined;
+  }
+
+  const normalised = categories
+    .map((category) => sanitiseFilterLabel(category))
+    .filter((category): category is string => Boolean(category));
+
+  if (normalised.length === 0) {
+    return undefined;
+  }
+
+  return Array.from(new Set(normalised));
+};
+
+export class EventService {
+  private readonly supabase: SupabaseClient;
+  private readonly logger: Pick<Console, 'error' | 'warn'>;
+
+  constructor(options: EventServiceOptions = {}) {
+    this.supabase = options.supabaseClient ?? supabase;
+    this.logger = options.logger ?? console;
+  }
+
+  private normaliseFilters(filters: EventServiceFilters = {}): EventServiceFilters {
+    const normalised: EventServiceFilters = {};
+
+    if (typeof filters.search === 'string') {
+      const sanitized = sanitizeSearchTerm(filters.search);
+      if (sanitized) {
+        normalised.search = sanitized;
+      }
+    }
+
+    if (typeof filters.location === 'string') {
+      const sanitizedLocation = sanitizeLocationTerm(filters.location);
+      if (sanitizedLocation) {
+        normalised.location = sanitizedLocation;
+      }
+    }
+
+    if (typeof filters.category === 'string') {
+      const trimmedCategory = filters.category.trim();
+      if (trimmedCategory) {
+        normalised.category = trimmedCategory;
+      }
+    }
+
+    if (typeof filters.date === 'string') {
+      const trimmedDate = filters.date.trim();
+      if (trimmedDate) {
+        if (ISO_DATE_REGEX.test(trimmedDate) && !Number.isNaN(Date.parse(trimmedDate))) {
+          normalised.date = trimmedDate;
+        } else {
+          this.logger.warn('Ignoring invalid date filter', { date: trimmedDate });
+        }
+      }
+    }
+
+    return normalised;
+  }
+
+  async fetchPublishedEvents(filters: EventServiceFilters = {}): Promise<Event[]> {
+    const normalisedFilters = this.normaliseFilters(filters);
+    const query = this.supabase
+      .from<EventRow>('events')
+      .select(`
+        *,
+        ticket_types (*)
+      `)
+      .eq('status', 'PUBLISHED');
+
+    if (normalisedFilters.search) {
+      query.or(`title.ilike.%${normalisedFilters.search}%,description.ilike.%${normalisedFilters.search}%`);
+    }
+
+    if (normalisedFilters.location) {
+      query.ilike('location', `%${normalisedFilters.location}%`);
+    }
+
+    if (normalisedFilters.date) {
+      query.eq('date', normalisedFilters.date);
+    }
+
+    if (normalisedFilters.category) {
+      query.contains('categories', [normalisedFilters.category]);
+    }
+
+    const { data, error } = await query.order('date', { ascending: true });
+
+    if (error) {
+      this.logger.error('Failed to fetch events:', error);
+      throw new Error('Failed to load events');
+    }
+
+    return (data ?? []).map((row) => ({
+      ...row,
+      ticket_types: row.ticket_types?.filter((ticket): ticket is TicketType => Boolean(ticket)) ?? [],
+      categories: normaliseCategoryList(row.categories),
+    }));
+  }
+
+  async fetchFilterMetadata(): Promise<{ locations: string[]; categories: string[] }> {
+    const { data, error } = await this.supabase
+      .from<EventFilterRow>('events')
+      .select('location, categories')
+      .eq('status', 'PUBLISHED');
+
+    if (error) {
+      this.logger.error('Failed to fetch event filter metadata:', error);
+      throw new Error('Failed to load event filters');
+    }
+
+    const locations = new Set<string>();
+    const categories = new Set<string>();
+
+    for (const row of data ?? []) {
+      const location = sanitiseFilterLabel(row.location);
+      if (location) {
+        locations.add(location);
+      }
+
+      for (const category of normaliseCategoryList(row.categories) ?? []) {
+        categories.add(category);
+      }
+    }
+
+    return {
+      locations: Array.from(locations).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+      categories: Array.from(categories).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+    };
+  }
+
+  subscribeToEventChanges(handler: () => void): RealtimeChannel {
+    const channel = this.supabase
+      .channel('events_channel')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'events',
+        },
+        handler,
+      )
+      .subscribe((status) => {
+        if (status === 'CHANNEL_ERROR') {
+          this.logger.error('Failed to subscribe to event changes');
+        }
+        if (status === 'TIMED_OUT') {
+          this.logger.warn('Subscription to event changes timed out');
+        }
+      });
+
+    return channel;
+  }
+}
+
+export const eventService = new EventService();
+

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,19 +1,20 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase-client';
 import { paymentMethodService } from './paymentMethodService';
 import { notificationTriggers } from './notificationTriggers';
 
 export interface CreatePaymentRequest {
   idempotency_key: string;
-  user_id?: string;  // optional for guest checkout
-  buyer_email?: string;  // for guest checkout
+  user_id?: string;
+  buyer_email?: string;
   event_id: string;
   ticket_lines: Array<{
     ticket_type_id: string;
     quantity: number;
-    price_major: number;  // major units (e.g., 5000 XOF)
+    price_major: number;
     currency: string;
   }>;
-  amount_major: number;  // major units for UI
+  amount_major: number;
   currency: string;
   method: 'mobile_money' | 'credit_card';
   phone?: string;
@@ -40,275 +41,397 @@ export interface PaymentVerification {
   message: string;
 }
 
-class PaymentService {
-  async createPayment(request: CreatePaymentRequest): Promise<PaymentResponse> {
+interface PaymentServiceOptions {
+  supabaseClient?: SupabaseClient;
+  fetch?: typeof fetch;
+  logger?: Pick<Console, 'error' | 'warn'>;
+}
+
+const PAYMENT_ERROR_MESSAGE = 'Échec de la création du paiement';
+const VERIFICATION_ERROR_MESSAGE = 'Échec de la vérification du paiement';
+
+export class PaymentService {
+  private readonly client: SupabaseClient;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: Pick<Console, 'error' | 'warn'>;
+
+  constructor(options: PaymentServiceOptions = {}) {
+    this.client = options.supabaseClient ?? supabase;
+
+    if (options.fetch) {
+      this.fetchImpl = options.fetch;
+    } else if (typeof fetch === 'function') {
+      this.fetchImpl = fetch.bind(globalThis);
+    } else {
+      throw new Error('Fetch API non disponible dans cet environnement');
+    }
+
+    this.logger = options.logger ?? console;
+  }
+
+  private getEnvValue(...keys: string[]): string | undefined {
+    for (const key of keys) {
+      try {
+        const value = (import.meta as ImportMeta)?.env?.[key as keyof ImportMetaEnv];
+        if (typeof value === 'string' && value.trim()) {
+          return value.trim();
+        }
+      } catch {
+        // ignore - import.meta may not exist
+      }
+
+      if (typeof process !== 'undefined' && process.env) {
+        const value = process.env[key];
+        if (typeof value === 'string' && value.trim()) {
+          return value.trim();
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private resolveFunctionConfig(): { url: string; anonKey: string } {
+    const url = this.getEnvValue('VITE_SUPABASE_URL', 'SUPABASE_URL');
+    const anonKey = this.getEnvValue('VITE_SUPABASE_ANON_KEY', 'SUPABASE_ANON_KEY');
+
+    if (!url) {
+      throw new Error('Configuration Supabase manquante (URL)');
+    }
+
+    if (!anonKey) {
+      throw new Error('Configuration Supabase manquante (clé Anon)');
+    }
+
+    return {
+      url: url.replace(/\/$/, ''),
+      anonKey,
+    };
+  }
+
+  private async readResponsePayload(response: Response): Promise<{ data: any; text: string | null }> {
+    let text: string | null = null;
+    let data: any = null;
+
     try {
-      console.log('Creating payment with request:', request);
-      
-      // Ensure the request is properly serialized
-      const requestBody = JSON.stringify(request);
-      console.log('Serialized request body:', requestBody);
-      
-      // Try direct fetch instead of supabase.functions.invoke
-      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-      const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-      
-      const response = await fetch(`${supabaseUrl}/functions/v1/create-payment`, {
+      const clone = response.clone();
+      const contentType = clone.headers.get('content-type');
+
+      if (contentType && contentType.toLowerCase().includes('application/json')) {
+        data = await clone.json();
+      } else {
+        text = await clone.text();
+        if (text) {
+          try {
+            data = JSON.parse(text);
+          } catch {
+            // ignore parsing error, fall back to raw text
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.warn?.('Impossible d\'analyser la réponse du service de paiement', error as Error);
+    }
+
+    if (data === null && text === null) {
+      try {
+        text = await response.clone().text();
+      } catch {
+        text = null;
+      }
+    }
+
+    return { data, text };
+  }
+
+  private extractErrorMessage(payload: unknown, text?: string | null): string | undefined {
+    if (payload && typeof payload === 'object') {
+      const candidate = (payload as { error?: string; message?: string }).error
+        ?? (payload as { message?: string }).message;
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+
+    if (text && text.trim()) {
+      return text.trim();
+    }
+
+    return undefined;
+  }
+
+  private sanitizePhone(value?: string): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const cleaned = value.replace(/[^+\d]/g, '').replace(/(?!^)\+/g, '');
+    return cleaned.trim() || undefined;
+  }
+
+  async createPayment(request: CreatePaymentRequest): Promise<PaymentResponse> {
+    if (!Array.isArray(request.ticket_lines) || request.ticket_lines.length === 0) {
+      throw new Error('Au moins un billet est requis pour créer un paiement');
+    }
+
+    if (!Number.isFinite(request.amount_major) || request.amount_major <= 0) {
+      throw new Error('Montant de paiement invalide');
+    }
+
+    const { url, anonKey } = this.resolveFunctionConfig();
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${url}/functions/v1/create-payment`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${supabaseAnonKey}`,
-          'apikey': supabaseAnonKey
+          Authorization: `Bearer ${anonKey}`,
+          apikey: anonKey,
         },
-        body: requestBody
+        body: JSON.stringify(request),
       });
-
-      console.log('Response status:', response.status);
-      console.log('Response headers:', Object.fromEntries(response.headers.entries()));
-
-      const responseText = await response.text();
-      console.log('Response text:', responseText);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${responseText}`);
-      }
-
-      let data;
-      try {
-        data = JSON.parse(responseText);
-      } catch (parseError) {
-        console.error('Failed to parse response:', parseError);
-        throw new Error(`Invalid response format: ${responseText}`);
-      }
-      
-      console.log('Payment service response:', data);
-      
-      if (!data) {
-        throw new Error('No response data from payment service');
-      }
-
-      if (!data.success) {
-        const errorMsg = data.error || 'Unknown payment error';
-        console.error('Payment creation failed:', errorMsg);
-        throw new Error(`Payment Error: ${errorMsg}`);
-      }
-      
-      return {
-        success: data.success,
-        payment_url: data.payment_url,
-        payment_token: data.payment_token,
-        payment_id: data.payment_id
-      };
-    } catch (error: any) {
-      console.error('Payment creation error:', error);
-      throw error;
+    } catch (error) {
+      this.logger.error('Erreur réseau lors de la création du paiement:', error as Error);
+      throw new Error('Impossible de contacter le service de paiement');
     }
+
+    const { data, text } = await this.readResponsePayload(response);
+
+    if (!response.ok) {
+      const message = this.extractErrorMessage(data, text);
+      throw new Error(message ? `${PAYMENT_ERROR_MESSAGE}: ${message}` : PAYMENT_ERROR_MESSAGE);
+    }
+
+    if (!data || data.success !== true) {
+      const message = this.extractErrorMessage(data, text);
+      throw new Error(message ?? PAYMENT_ERROR_MESSAGE);
+    }
+
+    if (typeof data.payment_token !== 'string' || !data.payment_token) {
+      throw new Error('Réponse de paiement invalide');
+    }
+
+    return {
+      success: true,
+      payment_url: typeof data.payment_url === 'string' ? data.payment_url : undefined,
+      payment_token: data.payment_token,
+      payment_id: typeof data.payment_id === 'string' ? data.payment_id : undefined,
+    };
   }
 
   async verifyPayment(paymentToken: string, orderId?: string, saveMethod?: boolean, paymentDetails?: any): Promise<PaymentVerification> {
-    try {
-      // Determine if token looks like UUID (internal_token) or Paydunya token (payment_token)
-      const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(paymentToken);
-      const isPaydunyaTestToken = paymentToken.startsWith('test_');
-      
-      console.log('Token analysis:', {
-        token: paymentToken,
-        isUUID,
-        isPaydunyaTestToken,
-        length: paymentToken.length
-      });
-
-      // Prepare payload for the deployed function
-      const payload: any = {
-        order_id: orderId || ''
-      };
-
-      // Send token in the appropriate field based on format
-      if (isUUID) {
-        payload.internal_token = paymentToken;
-        console.log('Sending as internal_token (UUID)');
-      } else {
-        payload.payment_token = paymentToken;
-        console.log('Sending as payment_token (Paydunya)');
-      }
-
-      const { data, error } = await supabase.functions.invoke('verify-payment', {
-        body: payload
-      });
-
-      if (error) {
-        console.error('Payment verification error:', error);
-        throw new Error(`Verification Error: ${error.message}`);
-      }
-
-      if (!data) {
-        throw new Error('No response data from verification service');
-      }
-
-      const result = {
-        success: data.success,
-        status: data.status,
-        payment_id: data.payment_id,
-        order_id: data.order_id || orderId,
-        test_mode: data.test_mode,
-        message: data.message || (data.status === 'completed' ? 'Payment verified successfully' : `Payment status: ${data.status}`)
-      };
-
-      console.log('Verification response from deployed function:', {
-        success: data.success,
-        status: data.status,
-        test_mode: data.test_mode,
-        message: data.message
-      });
-
-      // If payment was successful and user wants to save the method
-      if (result.success && result.status === 'completed' && saveMethod && paymentDetails) {
-        try {
-          await this.saveSuccessfulPaymentMethod(paymentDetails);
-        } catch (saveError) {
-          console.error('Error saving payment method:', saveError);
-          // Don't fail the verification if saving fails
-        }
-      }
-
-      // Trigger notification for successful payment
-      if (result.success && result.status === 'completed' && orderId) {
-        try {
-          // Get order details for notification
-          const { data: orderData } = await supabase
-            .from('orders')
-            .select(`
-              id,
-              user_id,
-              total,
-              currency,
-              events (title),
-              order_items (quantity)
-            `)
-            .eq('id', orderId)
-            .single();
-
-          if (orderData && orderData.user_id) {
-            const ticketCount = orderData.order_items?.reduce((sum: number, item: any) => sum + item.quantity, 0) || 1;
-            
-            await notificationTriggers.onOrderCreated({
-              order_id: orderId,
-              user_id: orderData.user_id,
-              event_title: orderData.events?.title || 'Événement',
-              total_amount: orderData.total,
-              currency: orderData.currency,
-              ticket_count: ticketCount
-            });
-          }
-        } catch (notificationError) {
-          console.error('Error creating order confirmation notification:', notificationError);
-          // Don't fail the verification if notification fails
-        }
-      }
-
-      return result;
-    } catch (error: any) {
-      console.error('Payment verification error:', error);
-      throw new Error(error.message || 'Failed to verify payment');
+    const trimmedToken = paymentToken?.trim();
+    if (!trimmedToken) {
+      throw new Error('Jeton de paiement requis');
     }
+
+    const payload: Record<string, unknown> = {
+      order_id: orderId ?? '',
+    };
+
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmedToken)) {
+      payload.internal_token = trimmedToken;
+    } else {
+      payload.payment_token = trimmedToken;
+    }
+
+    const { data, error } = await this.client.functions.invoke('verify-payment', {
+      body: payload,
+    });
+
+    if (error) {
+      this.logger.error('Erreur lors de la vérification du paiement:', error);
+      throw new Error(`${VERIFICATION_ERROR_MESSAGE}: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error('Réponse inattendue du service de vérification');
+    }
+
+    const result: PaymentVerification = {
+      success: Boolean(data.success),
+      status: typeof data.status === 'string' ? data.status : 'unknown',
+      payment_id: data.payment_id,
+      order_id: data.order_id ?? orderId,
+      message: data.message
+        ?? (data.status === 'completed'
+          ? 'Paiement vérifié avec succès'
+          : `Statut du paiement: ${data.status}`),
+    };
+
+    if (result.success && result.status === 'completed' && saveMethod && paymentDetails) {
+      await this.saveSuccessfulPaymentMethod(paymentDetails).catch((saveError) => {
+        this.logger.error('Erreur lors de l\'enregistrement du moyen de paiement:', saveError as Error);
+      });
+    }
+
+    if (result.success && result.status === 'completed' && orderId) {
+      await this.triggerOrderNotification(orderId).catch((notifyError) => {
+        this.logger.warn('Erreur lors de l\'envoi de la notification de commande', notifyError as Error);
+      });
+    }
+
+    return result;
+  }
+
+  private async triggerOrderNotification(orderId: string): Promise<void> {
+    const { data, error } = await this.client
+      .from('orders')
+      .select(`
+        id,
+        user_id,
+        total,
+        currency,
+        events (title),
+        order_items (quantity)
+      `)
+      .eq('id', orderId)
+      .single();
+
+    if (error || !data) {
+      throw error ?? new Error('Commande introuvable');
+    }
+
+    if (!data.user_id) {
+      return;
+    }
+
+    const ticketCount = Array.isArray(data.order_items)
+      ? data.order_items.reduce((sum: number, item: { quantity?: number }) => sum + (Number(item.quantity) || 0), 0)
+      : 0;
+
+    await notificationTriggers.onOrderCreated({
+      order_id: orderId,
+      user_id: data.user_id,
+      event_title: data.events?.title ?? 'Événement',
+      total_amount: data.total,
+      currency: data.currency,
+      ticket_count: ticketCount > 0 ? ticketCount : 1,
+    });
   }
 
   private async saveSuccessfulPaymentMethod(paymentDetails: any): Promise<void> {
-    try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return; // Can't save for guests
+    const { data, error } = await this.client.auth.getUser();
+    if (error || !data?.user) {
+      return;
+    }
 
-      if (paymentDetails.method === 'mobile_money' && paymentDetails.phone && paymentDetails.provider) {
+    if (paymentDetails?.method === 'mobile_money') {
+      const phone = this.sanitizePhone(paymentDetails.phone);
+      const provider = typeof paymentDetails.provider === 'string' ? paymentDetails.provider.trim().toLowerCase() : undefined;
+
+      if (!phone || !provider) {
+        return;
+      }
+
+      try {
         await paymentMethodService.savePaymentMethod({
           method_type: 'mobile_money',
-          provider: paymentDetails.provider,
-          account_number: paymentDetails.phone,
-          account_name: paymentDetails.accountName || '',
-          is_default: false
+          provider,
+          account_number: phone,
+          account_name: typeof paymentDetails.accountName === 'string' ? paymentDetails.accountName : '',
+          is_default: false,
         });
-      } else if (paymentDetails.method === 'credit_card' && paymentDetails.cardNumber) {
-        // Determine card provider from card number
-        const cardProvider = this.getCardProvider(paymentDetails.cardNumber);
-        
+      } catch (error) {
+        this.logger.error('Erreur lors de l\'enregistrement du moyen de paiement mobile:', error as Error);
+      }
+      return;
+    }
+
+    if (paymentDetails?.method === 'credit_card' && typeof paymentDetails.cardNumber === 'string') {
+      const digits = paymentDetails.cardNumber.replace(/\D/g, '');
+      if (!digits) {
+        return;
+      }
+
+      const lastFour = digits.slice(-4);
+      const masked = lastFour ? `****${lastFour}` : digits;
+      const provider = this.getCardProvider(digits);
+
+      try {
         await paymentMethodService.savePaymentMethod({
           method_type: 'credit_card',
-          provider: cardProvider,
-          account_number: paymentDetails.cardNumber,
-          account_name: paymentDetails.cardholderName || '',
-          is_default: false
+          provider,
+          account_number: masked,
+          account_name: typeof paymentDetails.cardholderName === 'string' ? paymentDetails.cardholderName : '',
+          is_default: false,
         });
+      } catch (error) {
+        this.logger.error('Erreur lors de l\'enregistrement du moyen de paiement carte:', error as Error);
       }
-    } catch (error) {
-      console.error('Error saving payment method:', error);
-      throw error;
     }
   }
 
   private getCardProvider(cardNumber: string): string {
     const cleanNumber = cardNumber.replace(/\D/g, '');
-    
-    // Visa
+
     if (cleanNumber.startsWith('4')) return 'Visa';
-    
-    // Mastercard (5xxx or 2xxx series)
-    if (cleanNumber.startsWith('5') || (cleanNumber.startsWith('2') && cleanNumber.length >= 2)) {
-      const firstTwo = cleanNumber.substring(0, 2);
-      if (cleanNumber.startsWith('5') || (parseInt(firstTwo) >= 22 && parseInt(firstTwo) <= 27)) {
+
+    if (cleanNumber.startsWith('5') || cleanNumber.startsWith('2')) {
+      const firstTwo = parseInt(cleanNumber.substring(0, 2), 10);
+      if (cleanNumber.startsWith('5') || (firstTwo >= 22 && firstTwo <= 27)) {
         return 'Mastercard';
       }
     }
-    
-    // American Express
+
     if (cleanNumber.startsWith('34') || cleanNumber.startsWith('37')) return 'American Express';
-    
-    // Discover
     if (cleanNumber.startsWith('6011') || cleanNumber.startsWith('65') || cleanNumber.startsWith('644') || cleanNumber.startsWith('645')) return 'Discover';
-    
-    // Diners Club
     if (cleanNumber.startsWith('30') || cleanNumber.startsWith('36') || cleanNumber.startsWith('38')) return 'Diners Club';
-    
-    // JCB
     if (cleanNumber.startsWith('35')) return 'JCB';
-    
-    // Union Pay
     if (cleanNumber.startsWith('62')) return 'Union Pay';
-    
-    // Default to "Carte" (Card) instead of "Unknown"
+
     return 'Carte';
   }
 
   async getPaymentStatus(paymentId: string) {
+    const trimmed = paymentId?.trim();
+    if (!trimmed) {
+      throw new Error('Identifiant de paiement requis');
+    }
+
     try {
-      const { data, error } = await supabase
+      const { data, error } = await this.client
         .from('payments')
         .select('*')
-        .eq('id', paymentId)
+        .eq('id', trimmed)
         .single();
 
-      if (error) throw error;
+      if (error) {
+        throw error;
+      }
+
       return data;
-    } catch (error: any) {
-      console.error('Error fetching payment status:', error);
-      throw new Error(error.message || 'Failed to get payment status');
+    } catch (error: unknown) {
+      this.logger.error('Erreur lors de la récupération du paiement:', error as Error);
+      throw new Error('Échec de la récupération du paiement');
     }
   }
 
   async getUserPayments(userId: string) {
+    const trimmed = userId?.trim();
+    if (!trimmed) {
+      return [];
+    }
+
     try {
-      const { data, error } = await supabase
+      const { data, error } = await this.client
         .from('payments')
         .select(`
           *,
           event:events(title, date, location)
         `)
-        .eq('user_id', userId)
+        .eq('user_id', trimmed)
         .order('created_at', { ascending: false });
 
-      if (error) throw error;
-      return data || [];
-    } catch (error: any) {
-      console.error('Error fetching user payments:', error);
-      throw new Error(error.message || 'Failed to get payment history');
+      if (error) {
+        throw error;
+      }
+
+      return data ?? [];
+    } catch (error: unknown) {
+      this.logger.error('Erreur lors de la récupération de l\'historique des paiements:', error as Error);
+      throw new Error('Échec de la récupération de l\'historique des paiements');
     }
   }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,22 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'public-anon-key');
+
+// Provide a default implementation for matchMedia which is not available in jsdom
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- guard auth configuration helpers against missing browser globals, expose richer password policies, and add unit coverage for redirect and validation logic
- rebuild the order service with dependency injection, strict quantity and ticket validations, safer Supabase interactions, and regression tests validating sanitisation and rollback behaviour
- scope notifications APIs to the authenticated user, harden realtime subscription teardown, and cover the new flows with focused unit tests
- refactor the payment service to normalise environment access, shield sensitive data, mask stored card numbers, and exercise both creation and verification paths with new tests

## Testing
- npm run test -- --run
- npm run lint *(fails: eslint CLI flags are incompatible with eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f1a9427c83209155d63ecd9010c1