### PR TITLE
Harden notification service and context

### DIFF
--- a/src/components/admin/events/EventForm.tsx
+++ b/src/components/admin/events/EventForm.tsx
@@ -1,0 +1,689 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import toast from 'react-hot-toast';
+
+import { CATEGORIES } from '../../../constants/categories';
+import { useTranslation } from '../../../context/TranslationContext';
+import type { Event, EventOrganizer, TicketType } from '../../../types/event';
+import {
+  ADMIN_EVENT_CURRENCIES,
+  ADMIN_EVENT_STATUSES,
+  adminEventSchema,
+  createAdminEvent,
+  updateAdminEvent,
+} from '../../../services/eventAdminService';
+
+interface EventFormProps {
+  event: (Event & { ticket_types?: TicketType[] | null }) | null;
+  organizers: EventOrganizer[];
+  onSuccess: () => Promise<void> | void;
+  onCancel: () => void;
+}
+
+interface TicketTypeDraft {
+  id?: string;
+  name: string;
+  description: string;
+  price: string;
+  quantity: string;
+  available: string;
+  max_per_order: string;
+}
+
+interface FormState {
+  title: string;
+  description: string;
+  date: string;
+  time: string;
+  location: string;
+  image_url: string;
+  price: string;
+  currency: string;
+  capacity: string;
+  status: string;
+  featured: boolean;
+  organizerId: string;
+  categories: string[];
+}
+
+type FieldErrors = Record<string, string>;
+
+const DEFAULT_CURRENCY = ADMIN_EVENT_CURRENCIES[0];
+const DEFAULT_STATUS = ADMIN_EVENT_STATUSES[0];
+
+const createEmptyTicketType = (): TicketTypeDraft => ({
+  name: '',
+  description: '',
+  price: '',
+  quantity: '',
+  available: '',
+  max_per_order: '1',
+});
+
+const toDecimal = (value: string): number => {
+  const normalized = value.replace(/,/g, '.').trim();
+  if (!normalized) return Number.NaN;
+  const parsed = Number.parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+};
+
+const toInteger = (value: string): number => {
+  const normalized = value.trim();
+  if (!normalized) return Number.NaN;
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+};
+
+const mapTicketTypeToDraft = (ticket: TicketType): TicketTypeDraft => ({
+  id: ticket.id,
+  name: ticket.name ?? '',
+  description: ticket.description ?? '',
+  price: ticket.price != null ? String(ticket.price) : '',
+  quantity: ticket.quantity != null ? String(ticket.quantity) : '',
+  available: ticket.available != null ? String(ticket.available) : '',
+  max_per_order: ticket.max_per_order != null ? String(ticket.max_per_order) : '1',
+});
+
+export default function EventForm({ event, organizers, onSuccess, onCancel }: EventFormProps) {
+  const { t } = useTranslation();
+  const [formState, setFormState] = useState<FormState>({
+    title: '',
+    description: '',
+    date: '',
+    time: '',
+    location: '',
+    image_url: '',
+    price: '',
+    currency: DEFAULT_CURRENCY,
+    capacity: '',
+    status: DEFAULT_STATUS,
+    featured: false,
+    organizerId: '',
+    categories: [],
+  });
+  const [ticketTypes, setTicketTypes] = useState<TicketTypeDraft[]>([createEmptyTicketType()]);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const categoryError = useMemo(() => {
+    if (errors['categories']) {
+      return errors['categories'];
+    }
+
+    const nestedEntry = Object.entries(errors).find(([key]) => key.startsWith('categories.'));
+    return nestedEntry?.[1];
+  }, [errors]);
+
+  const existingTicketTypeIds = useMemo(
+    () => event?.ticket_types?.map(ticket => ticket.id).filter((id): id is string => Boolean(id)) ?? [],
+    [event?.ticket_types],
+  );
+
+  useEffect(() => {
+    setFormState({
+      title: event?.title ?? '',
+      description: event?.description ?? '',
+      date: event?.date ?? '',
+      time: event?.time ?? '',
+      location: event?.location ?? '',
+      image_url: event?.image_url ?? '',
+      price: event?.price != null ? String(event.price) : '',
+      currency: event?.currency ?? DEFAULT_CURRENCY,
+      capacity: event?.capacity != null ? String(event.capacity) : '',
+      status: event?.status ?? DEFAULT_STATUS,
+      featured: Boolean(event?.featured),
+      organizerId: event?.organizer_id ?? '',
+      categories: event?.categories?.slice() ?? [],
+    });
+
+    if (event?.ticket_types && event.ticket_types.length > 0) {
+      setTicketTypes(event.ticket_types.map(mapTicketTypeToDraft));
+    } else {
+      setTicketTypes([createEmptyTicketType()]);
+    }
+
+    setErrors({});
+  }, [event]);
+
+  const updateFormState = (changes: Partial<FormState>) => {
+    setFormState(prev => ({ ...prev, ...changes }));
+  };
+
+  const updateTicketType = (index: number, changes: Partial<TicketTypeDraft>) => {
+    setTicketTypes(prev => prev.map((ticket, currentIndex) => (currentIndex === index ? { ...ticket, ...changes } : ticket)));
+  };
+
+  const handleCategoryToggle = (categoryId: string) => {
+    setFormState(prev => {
+      const categories = new Set(prev.categories);
+      if (categories.has(categoryId)) {
+        categories.delete(categoryId);
+      } else {
+        categories.add(categoryId);
+      }
+
+      return { ...prev, categories: Array.from(categories) };
+    });
+  };
+
+  const addTicketType = () => {
+    setTicketTypes(prev => [...prev, createEmptyTicketType()]);
+  };
+
+  const removeTicketType = (index: number) => {
+    setTicketTypes(prev => (prev.length === 1 ? prev : prev.filter((_, currentIndex) => currentIndex !== index)));
+  };
+
+  const buildPayload = () => {
+    const parsedTicketTypes = ticketTypes.map(ticket => {
+      const quantity = toInteger(ticket.quantity);
+      const available = ticket.available.trim()
+        ? toInteger(ticket.available)
+        : quantity;
+
+      return {
+        id: ticket.id,
+        name: ticket.name,
+        description: ticket.description,
+        price: toDecimal(ticket.price),
+        quantity,
+        available,
+        max_per_order: toInteger(ticket.max_per_order),
+      };
+    });
+
+    return {
+      title: formState.title,
+      description: formState.description,
+      date: formState.date,
+      time: formState.time,
+      location: formState.location,
+      image_url: formState.image_url,
+      price: toDecimal(formState.price),
+      currency: formState.currency,
+      capacity: toInteger(formState.capacity),
+      status: formState.status,
+      featured: formState.featured,
+      organizer_id: formState.organizerId || null,
+      categories: formState.categories,
+      ticket_types: parsedTicketTypes,
+    };
+  };
+
+  const handleSubmit = async (eventObject: React.FormEvent<HTMLFormElement>) => {
+    eventObject.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const payload = buildPayload();
+      const parsed = adminEventSchema.safeParse(payload);
+
+      if (!parsed.success) {
+        const nextErrors: FieldErrors = {};
+        for (const issue of parsed.error.issues) {
+          const pathKey = issue.path.join('.');
+          if (!nextErrors[pathKey]) {
+            nextErrors[pathKey] = issue.message;
+          }
+        }
+        setErrors(nextErrors);
+        toast.error(t('admin.events.error.validation', { default: 'Please correct the highlighted errors.' }));
+        return;
+      }
+
+      setErrors({});
+
+      if (event) {
+        await updateAdminEvent(event.id, parsed.data, existingTicketTypeIds);
+        toast.success(t('admin.events.success.update', { default: 'Event updated successfully' }));
+      } else {
+        await createAdminEvent(parsed.data);
+        toast.success(t('admin.events.success.create', { default: 'Event created successfully' }));
+      }
+
+      await onSuccess?.();
+    } catch (error) {
+      console.error('Failed to save event', error);
+      const message = error instanceof Error ? error.message : undefined;
+      toast.error(
+        message && message.trim().length > 0
+          ? message
+          : t('admin.events.error.save', { default: 'Failed to save event' }),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const getError = (path: string) => errors[path];
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <section className="bg-white rounded-xl shadow-sm p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.title', { default: 'Title' })}
+            </label>
+            <input
+              type="text"
+              value={formState.title}
+              onChange={event => updateFormState({ title: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('title') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+              placeholder={t('admin.events.form.title_placeholder', { default: 'Enter event title' })}
+            />
+            {getError('title') && <p className="mt-1 text-sm text-red-600">{getError('title')}</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.organizer', { default: 'Organizer' })}
+            </label>
+            <select
+              value={formState.organizerId}
+              onChange={event => updateFormState({ organizerId: event.target.value })}
+              className="mt-1 block w-full rounded-lg border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            >
+              <option value="">
+                {t('admin.events.form.no_organizer', { default: 'No organizer assigned' })}
+              </option>
+              {organizers.map(organizer => (
+                <option key={organizer.user_id} value={organizer.user_id}>
+                  {organizer.name} — {organizer.email}
+                </option>
+              ))}
+            </select>
+            {getError('organizer_id') && <p className="mt-1 text-sm text-red-600">{getError('organizer_id')}</p>}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700">
+            {t('admin.events.form.description', { default: 'Description' })}
+          </label>
+          <textarea
+            value={formState.description}
+            onChange={event => updateFormState({ description: event.target.value })}
+            rows={4}
+            className={`mt-1 block w-full rounded-lg border ${
+              getError('description') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+            } shadow-sm focus:border-indigo-500`}
+            placeholder={t('admin.events.form.description_placeholder', {
+              default: 'Describe the event, highlights and important information',
+            })}
+          />
+          {getError('description') && <p className="mt-1 text-sm text-red-600">{getError('description')}</p>}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.date', { default: 'Date' })}
+            </label>
+            <input
+              type="date"
+              value={formState.date}
+              onChange={event => updateFormState({ date: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('date') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+            />
+            {getError('date') && <p className="mt-1 text-sm text-red-600">{getError('date')}</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.time', { default: 'Time' })}
+            </label>
+            <input
+              type="time"
+              value={formState.time}
+              onChange={event => updateFormState({ time: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('time') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+            />
+            {getError('time') && <p className="mt-1 text-sm text-red-600">{getError('time')}</p>}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.location', { default: 'Location' })}
+            </label>
+            <input
+              type="text"
+              value={formState.location}
+              onChange={event => updateFormState({ location: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('location') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+              placeholder={t('admin.events.form.location_placeholder', { default: 'Enter venue or address' })}
+            />
+            {getError('location') && <p className="mt-1 text-sm text-red-600">{getError('location')}</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.image', { default: 'Image URL' })}
+            </label>
+            <input
+              type="url"
+              value={formState.image_url}
+              onChange={event => updateFormState({ image_url: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('image_url') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+              placeholder={t('admin.events.form.image_placeholder', { default: 'https://example.com/event.jpg' })}
+            />
+            {getError('image_url') && <p className="mt-1 text-sm text-red-600">{getError('image_url')}</p>}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.price', { default: 'Base Price' })}
+            </label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={formState.price}
+              onChange={event => updateFormState({ price: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('price') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+              placeholder="0.00"
+            />
+            {getError('price') && <p className="mt-1 text-sm text-red-600">{getError('price')}</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.currency', { default: 'Currency' })}
+            </label>
+            <select
+              value={formState.currency}
+              onChange={event => updateFormState({ currency: event.target.value })}
+              className="mt-1 block w-full rounded-lg border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            >
+              {ADMIN_EVENT_CURRENCIES.map(currency => (
+                <option key={currency} value={currency}>
+                  {currency}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.capacity', { default: 'Capacity' })}
+            </label>
+            <input
+              type="number"
+              min="1"
+              value={formState.capacity}
+              onChange={event => updateFormState({ capacity: event.target.value })}
+              className={`mt-1 block w-full rounded-lg border ${
+                getError('capacity') ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+              } shadow-sm focus:border-indigo-500`}
+              placeholder="100"
+            />
+            {getError('capacity') && <p className="mt-1 text-sm text-red-600">{getError('capacity')}</p>}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-center">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.events.form.status', { default: 'Status' })}
+            </label>
+            <select
+              value={formState.status}
+              onChange={event => updateFormState({ status: event.target.value })}
+              className="mt-1 block w-full rounded-lg border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            >
+              {ADMIN_EVENT_STATUSES.map(statusValue => (
+                <option key={statusValue} value={statusValue}>
+                  {statusValue === 'DRAFT'
+                    ? t('admin.events.status.draft', { default: 'Draft' })
+                    : statusValue === 'PUBLISHED'
+                    ? t('admin.events.status.published', { default: 'Published' })
+                    : statusValue === 'CANCELLED'
+                    ? t('admin.events.status.cancelled', { default: 'Cancelled' })
+                    : t('admin.events.status.completed', { default: 'Completed' })}
+                </option>
+              ))}
+            </select>
+            {getError('status') && <p className="mt-1 text-sm text-red-600">{getError('status')}</p>}
+          </div>
+
+          <div className="flex items-center gap-2 pt-6">
+            <input
+              id="featured"
+              type="checkbox"
+              checked={formState.featured}
+              onChange={event => updateFormState({ featured: event.target.checked })}
+              className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            <label htmlFor="featured" className="text-sm font-medium text-gray-700">
+              {t('admin.events.form.featured', { default: 'Mark as featured' })}
+            </label>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-medium text-gray-700 mb-2">
+            {t('admin.events.form.categories', { default: 'Categories' })}
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+            {CATEGORIES.map(category => {
+              const isChecked = formState.categories.includes(category.id);
+              return (
+                <label
+                  key={category.id}
+                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 cursor-pointer transition ${
+                    isChecked ? 'border-indigo-500 bg-indigo-50 text-indigo-700' : 'border-gray-200 bg-white text-gray-700'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={() => handleCategoryToggle(category.id)}
+                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span className="text-sm font-medium">{category.name}</span>
+                </label>
+              );
+            })}
+          </div>
+          {getError('categories') && <p className="mt-2 text-sm text-red-600">{getError('categories')}</p>}
+          {!getError('categories') && categoryError && <p className="mt-2 text-sm text-red-600">{categoryError}</p>}
+        </div>
+      </section>
+
+      <section className="bg-white rounded-xl shadow-sm p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {t('admin.events.form.ticket_types', { default: 'Ticket types' })}
+          </h2>
+          <button
+            type="button"
+            onClick={addTicketType}
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <Plus className="h-4 w-4" />
+            {t('admin.events.form.ticket_add', { default: 'Add ticket type' })}
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          {ticketTypes.map((ticket, index) => {
+            const nameKey = `ticket_types.${index}.name`;
+            const priceKey = `ticket_types.${index}.price`;
+            const quantityKey = `ticket_types.${index}.quantity`;
+            const availableKey = `ticket_types.${index}.available`;
+            const maxPerOrderKey = `ticket_types.${index}.max_per_order`;
+
+            return (
+              <div key={ticket.id ?? index} className="rounded-lg border border-gray-200 p-4 space-y-4">
+                <div className="flex justify-between items-start">
+                  <h3 className="text-sm font-semibold text-gray-900">
+                    {t('admin.events.form.ticket_label', { default: 'Ticket type {index}', index: index + 1 })}
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={() => removeTicketType(index)}
+                    className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                    disabled={ticketTypes.length === 1}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    {t('common.remove', { default: 'Remove' })}
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">
+                      {t('admin.events.form.ticket_name', { default: 'Name' })}
+                    </label>
+                    <input
+                      type="text"
+                      value={ticket.name}
+                      onChange={event => updateTicketType(index, { name: event.target.value })}
+                      className={`mt-1 block w-full rounded-lg border ${
+                        getError(nameKey) ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+                      } shadow-sm focus:border-indigo-500`}
+                      placeholder={t('admin.events.form.ticket_name_placeholder', { default: 'General Admission' })}
+                    />
+                    {getError(nameKey) && <p className="mt-1 text-sm text-red-600">{getError(nameKey)}</p>}
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">
+                      {t('admin.events.form.ticket_price', { default: 'Price' })}
+                    </label>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={ticket.price}
+                      onChange={event => updateTicketType(index, { price: event.target.value })}
+                      className={`mt-1 block w-full rounded-lg border ${
+                        getError(priceKey) ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+                      } shadow-sm focus:border-indigo-500`}
+                      placeholder="0.00"
+                    />
+                    {getError(priceKey) && <p className="mt-1 text-sm text-red-600">{getError(priceKey)}</p>}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">
+                    {t('admin.events.form.ticket_description', { default: 'Description' })}
+                  </label>
+                  <textarea
+                    value={ticket.description}
+                    onChange={event => updateTicketType(index, { description: event.target.value })}
+                    rows={3}
+                    className={`mt-1 block w-full rounded-lg border ${
+                      getError(`ticket_types.${index}.description`)
+                        ? 'border-red-500 focus:ring-red-500'
+                        : 'border-gray-300 focus:ring-indigo-500'
+                    } shadow-sm focus:border-indigo-500`}
+                    placeholder={t('admin.events.form.ticket_description_placeholder', {
+                      default: 'Describe seating, benefits or access level',
+                    })}
+                  />
+                  {getError(`ticket_types.${index}.description`) && (
+                    <p className="mt-1 text-sm text-red-600">{getError(`ticket_types.${index}.description`)}</p>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">
+                      {t('admin.events.form.ticket_quantity', { default: 'Quantity' })}
+                    </label>
+                    <input
+                      type="number"
+                      min="0"
+                      value={ticket.quantity}
+                      onChange={event => updateTicketType(index, { quantity: event.target.value })}
+                      className={`mt-1 block w-full rounded-lg border ${
+                        getError(quantityKey) ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+                      } shadow-sm focus:border-indigo-500`}
+                      placeholder="0"
+                    />
+                    {getError(quantityKey) && <p className="mt-1 text-sm text-red-600">{getError(quantityKey)}</p>}
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">
+                      {t('admin.events.form.ticket_available', { default: 'Available' })}
+                    </label>
+                    <input
+                      type="number"
+                      min="0"
+                      value={ticket.available}
+                      onChange={event => updateTicketType(index, { available: event.target.value })}
+                      className={`mt-1 block w-full rounded-lg border ${
+                        getError(availableKey) ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-indigo-500'
+                      } shadow-sm focus:border-indigo-500`}
+                      placeholder={t('admin.events.form.ticket_available_placeholder', { default: 'Defaults to quantity' })}
+                    />
+                    {getError(availableKey) && <p className="mt-1 text-sm text-red-600">{getError(availableKey)}</p>}
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700">
+                      {t('admin.events.form.ticket_max_per_order', { default: 'Max per order' })}
+                    </label>
+                    <input
+                      type="number"
+                      min="1"
+                      value={ticket.max_per_order}
+                      onChange={event => updateTicketType(index, { max_per_order: event.target.value })}
+                      className={`mt-1 block w-full rounded-lg border ${
+                        getError(maxPerOrderKey)
+                          ? 'border-red-500 focus:ring-red-500'
+                          : 'border-gray-300 focus:ring-indigo-500'
+                      } shadow-sm focus:border-indigo-500`}
+                      placeholder="1"
+                    />
+                    {getError(maxPerOrderKey) && <p className="mt-1 text-sm text-red-600">{getError(maxPerOrderKey)}</p>}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+          disabled={isSubmitting}
+        >
+          {t('common.cancel', { default: 'Cancel' })}
+        </button>
+        <button
+          type="submit"
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60"
+          disabled={isSubmitting}
+        >
+          {isSubmitting
+            ? t('admin.events.form.saving', { default: 'Saving...' })
+            : event
+            ? t('admin.events.form.update', { default: 'Update event' })
+            : t('admin.events.form.create', { default: 'Create event' })}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/profile/Notifications.tsx
+++ b/src/components/profile/Notifications.tsx
@@ -78,8 +78,8 @@ export default function Notifications() {
         [key]: value
       };
 
-      await notificationService.updatePreferences(updatedPreferences);
-      setPreferences(updatedPreferences);
+      const savedPreferences = await notificationService.updatePreferences(updatedPreferences);
+      setPreferences(savedPreferences);
       toast.success(
         t('notifications.updated', {
           channel: t(`notifications.channels.${key}`, { default: key }),
@@ -114,8 +114,8 @@ export default function Notifications() {
         types: newTypes
       };
 
-      await notificationService.updatePreferences(updatedPreferences);
-      setPreferences(updatedPreferences);
+      const savedPreferences = await notificationService.updatePreferences(updatedPreferences);
+      setPreferences(savedPreferences);
       
       const type = NOTIFICATION_TYPES.find(t => t.id === typeId);
       if (type) {

--- a/src/config/__tests__/auth.test.ts
+++ b/src/config/__tests__/auth.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { AUTH_CONFIG, validatePassword } from '../auth';
+
+const originalRequirements = { ...AUTH_CONFIG.PASSWORD_REQUIREMENTS };
+
+afterEach(() => {
+  Object.assign(AUTH_CONFIG.PASSWORD_REQUIREMENTS, originalRequirements);
+});
+
+describe('validatePassword', () => {
+  it('fails when optional requirements are enabled but not met', () => {
+    Object.assign(AUTH_CONFIG.PASSWORD_REQUIREMENTS, {
+      ...originalRequirements,
+      REQUIRE_UPPERCASE: true,
+      REQUIRE_LOWERCASE: true,
+      REQUIRE_NUMBERS: true,
+      REQUIRE_SPECIAL_CHARS: true,
+    });
+
+    const result = validatePassword('password');
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Le mot de passe doit contenir au moins une lettre majuscule');
+    expect(result.errors).toContain('Le mot de passe doit contenir au moins un chiffre');
+    expect(result.errors).toContain('Le mot de passe doit contenir au moins un caractère spécial');
+  });
+
+  it('passes when all requirements are satisfied', () => {
+    Object.assign(AUTH_CONFIG.PASSWORD_REQUIREMENTS, {
+      ...originalRequirements,
+      REQUIRE_UPPERCASE: true,
+      REQUIRE_LOWERCASE: true,
+      REQUIRE_NUMBERS: true,
+      REQUIRE_SPECIAL_CHARS: true,
+    });
+
+    const result = validatePassword('Password1!');
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -49,14 +49,36 @@ export const getRedirectUrl = (type: keyof typeof AUTH_CONFIG.REDIRECT_URLS): st
 // Helper function to validate password strength
 export const validatePassword = (password: string): { isValid: boolean; errors: string[] } => {
   const errors: string[] = [];
-  const { MIN_LENGTH } = AUTH_CONFIG.PASSWORD_REQUIREMENTS;
-  
+  const {
+    MIN_LENGTH,
+    REQUIRE_UPPERCASE,
+    REQUIRE_LOWERCASE,
+    REQUIRE_NUMBERS,
+    REQUIRE_SPECIAL_CHARS,
+  } = AUTH_CONFIG.PASSWORD_REQUIREMENTS;
+
   if (password.length < MIN_LENGTH) {
     errors.push(`Le mot de passe doit contenir au moins ${MIN_LENGTH} caractères`);
   }
-  
+
+  if (REQUIRE_UPPERCASE && !/[A-Z]/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins une lettre majuscule');
+  }
+
+  if (REQUIRE_LOWERCASE && !/[a-z]/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins une lettre minuscule');
+  }
+
+  if (REQUIRE_NUMBERS && !/\d/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins un chiffre');
+  }
+
+  if (REQUIRE_SPECIAL_CHARS && !/[!@#$%^&*(),.?":{}|<>\[\];'`~\/\\+\-=_]/.test(password)) {
+    errors.push('Le mot de passe doit contenir au moins un caractère spécial');
+  }
+
   return {
     isValid: errors.length === 0,
     errors
   };
-}; 
+};

--- a/src/services/__tests__/authService.test.ts
+++ b/src/services/__tests__/authService.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const authMock = {
+    signInWithPassword: vi.fn(),
+    signOut: vi.fn(),
+    getSession: vi.fn(),
+    getUser: vi.fn(),
+    resetPasswordForEmail: vi.fn(),
+    updateUser: vi.fn(),
+  };
+
+  const createProfileBuilder = () => {
+    const builder = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      maybeSingle: vi.fn(),
+    };
+
+    builder.select.mockReturnValue(builder);
+    builder.eq.mockReturnValue(builder);
+    builder.maybeSingle.mockResolvedValue({ data: { id: 'profile-id' }, error: null });
+
+    return builder;
+  };
+
+  let currentProfileBuilder = createProfileBuilder();
+  const fromMock = vi.fn(() => currentProfileBuilder);
+
+  const resetProfileBuilder = () => {
+    currentProfileBuilder = createProfileBuilder();
+    fromMock.mockImplementation(() => currentProfileBuilder);
+    return currentProfileBuilder;
+  };
+
+  return {
+    authMock,
+    fromMock,
+    resetProfileBuilder,
+    getProfileBuilder: () => currentProfileBuilder,
+  };
+});
+
+vi.mock('../../lib/supabase-client', () => ({
+  supabase: {
+    auth: mocks.authMock,
+    from: mocks.fromMock,
+  },
+}));
+
+import { authService } from '../authService';
+
+const { authMock, resetProfileBuilder, getProfileBuilder } = mocks;
+
+describe('authService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    resetProfileBuilder();
+
+    authMock.signInWithPassword.mockResolvedValue({
+      data: {
+        user: { id: 'user-id', email: 'user@example.com' },
+        session: { access_token: 'token' }
+      },
+      error: null,
+    });
+
+    authMock.signOut.mockResolvedValue({ error: null });
+    authMock.getSession.mockResolvedValue({ data: { session: null }, error: null });
+    authMock.getUser.mockResolvedValue({ data: { user: { id: 'user-id' } }, error: null });
+    authMock.resetPasswordForEmail.mockResolvedValue({ error: null });
+    authMock.updateUser.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  describe('register', () => {
+    it('rejects weak passwords before calling the signup endpoint', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(authService.register({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'short',
+      })).rejects.toThrow('Le mot de passe doit contenir au moins 8 caractères');
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors returned by the signup endpoint', async () => {
+      vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+      vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+
+      const responseJson = { success: false, error: 'Email déjà utilisé' };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: {
+          get: (name: string) => name.toLowerCase() === 'content-type' ? 'application/json' : null,
+        },
+        json: vi.fn().mockResolvedValue(responseJson),
+      });
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(authService.register({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'Password123',
+      })).rejects.toThrow('Email déjà utilisé');
+
+      expect(authMock.signInWithPassword).not.toHaveBeenCalled();
+    });
+
+    it('normalises email before attempting login after registration', async () => {
+      vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+      vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) => name.toLowerCase() === 'content-type' ? 'application/json' : null,
+        },
+        json: vi.fn().mockResolvedValue({ success: true }),
+      });
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      const signInSpy = authMock.signInWithPassword.mockImplementation(async (params) => ({
+        data: {
+          user: { id: 'user-id', email: params.email },
+          session: { access_token: 'token' },
+        },
+        error: null,
+      }));
+
+      getProfileBuilder().maybeSingle.mockResolvedValue({ data: { id: 'profile-id' }, error: null });
+
+      const result = await authService.register({
+        name: ' Test User ',
+        email: ' USER@example.com ',
+        password: 'Password123',
+      });
+
+      expect(signInSpy).toHaveBeenCalledWith({
+        email: 'USER@example.com',
+        password: 'Password123',
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result.user.email).toBe('USER@example.com');
+    });
+  });
+});

--- a/src/services/__tests__/eventAdminService.test.ts
+++ b/src/services/__tests__/eventAdminService.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const eventInsertMaybeSingle = vi.fn().mockResolvedValue({ data: { id: 'event-id' }, error: null });
+  const eventInsertSelect = vi.fn(() => ({ maybeSingle: eventInsertMaybeSingle }));
+  const eventsInsert = vi.fn(() => ({ select: eventInsertSelect }));
+  const eventsUpdateEq = vi.fn().mockResolvedValue({ error: null });
+  const eventsUpdate = vi.fn(() => ({ eq: eventsUpdateEq }));
+  const eventsDeleteEq = vi.fn().mockResolvedValue({ error: null });
+  const eventsDelete = vi.fn(() => ({ eq: eventsDeleteEq }));
+
+  const ticketInsert = vi.fn().mockResolvedValue({ error: null });
+  const ticketUpsert = vi.fn().mockResolvedValue({ error: null });
+  const ticketDeleteIn = vi.fn().mockResolvedValue({ error: null });
+  const ticketDelete = vi.fn(() => ({ in: ticketDeleteIn }));
+
+  const eventsBuilder = {
+    insert: eventsInsert,
+    update: eventsUpdate,
+    delete: eventsDelete,
+  };
+
+  const ticketTypesBuilder = {
+    insert: ticketInsert,
+    upsert: ticketUpsert,
+    delete: ticketDelete,
+  };
+
+  const fromMock = vi.fn((table: string) => {
+    if (table === 'events') return eventsBuilder;
+    if (table === 'ticket_types') return ticketTypesBuilder;
+    throw new Error(`Unexpected table ${table}`);
+  });
+
+  const reset = () => {
+    eventsInsert.mockClear();
+    eventInsertSelect.mockClear();
+    eventInsertMaybeSingle.mockClear();
+    eventsUpdate.mockClear();
+    eventsUpdateEq.mockClear();
+    eventsDelete.mockClear();
+    eventsDeleteEq.mockClear();
+    ticketInsert.mockClear();
+    ticketUpsert.mockClear();
+    ticketDelete.mockClear();
+    ticketDeleteIn.mockClear();
+    fromMock.mockClear();
+
+    eventInsertMaybeSingle.mockResolvedValue({ data: { id: 'event-id' }, error: null });
+    eventsUpdateEq.mockResolvedValue({ error: null });
+    eventsDeleteEq.mockResolvedValue({ error: null });
+    ticketInsert.mockResolvedValue({ error: null });
+    ticketUpsert.mockResolvedValue({ error: null });
+    ticketDeleteIn.mockResolvedValue({ error: null });
+  };
+
+  return {
+    eventsBuilder,
+    ticketTypesBuilder,
+    eventInsertSelect,
+    eventInsertMaybeSingle,
+    eventsUpdateEq,
+    eventsDeleteEq,
+    ticketInsert,
+    ticketUpsert,
+    ticketDeleteIn,
+    fromMock,
+    reset,
+  };
+});
+
+vi.mock('../../lib/supabase-client', () => ({
+  supabase: {
+    from: mocks.fromMock,
+  },
+}));
+
+import {
+  ADMIN_EVENT_CURRENCIES,
+  adminEventSchema,
+  createAdminEvent,
+  updateAdminEvent,
+} from '../eventAdminService';
+
+const { reset, ticketInsert, ticketUpsert, ticketDeleteIn, eventsBuilder, eventsUpdateEq, eventsDeleteEq } = mocks;
+
+const baseInput = {
+  title: '  Sample Event  ',
+  description: 'A wonderful event',
+  date: '2024-01-01',
+  time: '12:00',
+  location: 'Main hall',
+  image_url: 'https://example.com/event.jpg',
+  price: 25,
+  currency: ADMIN_EVENT_CURRENCIES[0],
+  capacity: 150,
+  status: 'DRAFT' as const,
+  featured: false,
+  organizer_id: null as string | null,
+  categories: [] as string[],
+  ticket_types: [
+    {
+      name: 'General',
+      description: 'Access to the main floor',
+      price: 25,
+      quantity: 100,
+      available: 100,
+      max_per_order: 5,
+    },
+  ],
+};
+
+describe('adminEventSchema', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('rejects ticket configurations where available exceeds quantity', () => {
+    const result = adminEventSchema.safeParse({
+      ...baseInput,
+      ticket_types: [
+        {
+          name: 'VIP',
+          description: 'Exclusive access',
+          price: 120,
+          quantity: 10,
+          available: 15,
+          max_per_order: 2,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('Available tickets cannot exceed total quantity');
+    }
+  });
+
+  it('rejects unknown categories', () => {
+    const result = adminEventSchema.safeParse({
+      ...baseInput,
+      categories: ['unknown-category'],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('Unknown category');
+    }
+  });
+
+  it('enforces HTTPS image URLs', () => {
+    const result = adminEventSchema.safeParse({
+      ...baseInput,
+      image_url: 'http://example.com/event.jpg',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(issue => issue.message.includes('Image URL must use HTTPS'))).toBe(true);
+    }
+  });
+
+  it('rejects non-finite monetary values for events and tickets', () => {
+    const result = adminEventSchema.safeParse({
+      ...baseInput,
+      price: Number.POSITIVE_INFINITY,
+      ticket_types: [
+        {
+          ...baseInput.ticket_types[0],
+          price: Number.POSITIVE_INFINITY,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(issue => issue.message.includes('Event price must be a valid amount'))).toBe(true);
+      expect(result.error.issues.some(issue => issue.message.includes('Ticket price must be a valid amount'))).toBe(true);
+    }
+  });
+});
+
+describe('createAdminEvent', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('persists a new event and ticket types with sanitized values', async () => {
+    const payload = { ...baseInput };
+
+    const eventId = await createAdminEvent(payload);
+
+    expect(eventId).toBe('event-id');
+    expect(eventsBuilder.insert).toHaveBeenCalledTimes(1);
+    const insertedEvent = eventsBuilder.insert.mock.calls[0]?.[0]?.[0];
+    expect(insertedEvent.title).toBe('Sample Event');
+    expect(insertedEvent.categories).toEqual([]);
+
+    expect(ticketInsert).toHaveBeenCalledTimes(1);
+    const insertedTickets = ticketInsert.mock.calls[0]?.[0];
+    expect(insertedTickets).toEqual([
+      {
+        event_id: 'event-id',
+        name: 'General',
+        description: 'Access to the main floor',
+        price: 25,
+        quantity: 100,
+        available: 100,
+        max_per_order: 5,
+      },
+    ]);
+  });
+
+  it('rolls back the event record when ticket creation fails', async () => {
+    ticketInsert.mockResolvedValueOnce({ error: { message: 'ticket error' } });
+
+    await expect(createAdminEvent(baseInput)).rejects.toThrow('ticket error');
+
+    expect(eventsDeleteEq).toHaveBeenCalledWith('id', 'event-id');
+  });
+});
+
+describe('updateAdminEvent', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('updates the event, synchronizes existing ticket types, and removes stale ones', async () => {
+    const payload = {
+      ...baseInput,
+      status: 'PUBLISHED' as const,
+      ticket_types: [
+        {
+          id: '8b8c42a8-9895-4d7f-855c-0b1ed257a7f1',
+          name: 'General',
+          description: 'Access to the main floor',
+          price: 35,
+          quantity: 120,
+          available: 110,
+          max_per_order: 6,
+        },
+        {
+          name: 'VIP',
+          description: 'Exclusive balcony seats',
+          price: 150,
+          quantity: 20,
+          available: 20,
+          max_per_order: 2,
+        },
+      ],
+    };
+
+    await updateAdminEvent('event-id', payload, [
+      '8b8c42a8-9895-4d7f-855c-0b1ed257a7f1',
+      'f2fe3c6d-a0c0-4e6c-9b71-4c6e97ec5d9a',
+    ]);
+
+    expect(eventsUpdateEq).toHaveBeenCalledWith('id', 'event-id');
+    expect(ticketUpsert).toHaveBeenCalledWith(
+      [
+        {
+          id: '8b8c42a8-9895-4d7f-855c-0b1ed257a7f1',
+          event_id: 'event-id',
+          name: 'General',
+          description: 'Access to the main floor',
+          price: 35,
+          quantity: 120,
+          available: 110,
+          max_per_order: 6,
+        },
+      ],
+      { onConflict: 'id' },
+    );
+
+    expect(ticketInsert).toHaveBeenCalledWith([
+      {
+        event_id: 'event-id',
+        name: 'VIP',
+        description: 'Exclusive balcony seats',
+        price: 150,
+        quantity: 20,
+        available: 20,
+        max_per_order: 2,
+      },
+    ]);
+
+    expect(ticketDeleteIn).toHaveBeenCalledWith('id', ['f2fe3c6d-a0c0-4e6c-9b71-4c6e97ec5d9a']);
+  });
+});

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const authMock = {
+    getUser: vi.fn(),
+  };
+
+  const fromMock = vi.fn();
+  const channelMock = vi.fn();
+  const removeChannelMock = vi.fn();
+
+  const createSelectBuilder = (response: any, thenResponse: any = response) => {
+    const builder: any = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      limit: vi.fn(() => Promise.resolve(response)),
+      range: vi.fn(() => Promise.resolve(response)),
+    };
+    builder.then = (resolve: any, reject: any) => Promise.resolve(thenResponse).then(resolve, reject);
+    return builder;
+  };
+
+  const createUpdateBuilder = (selectResponse: any, thenResponse: any) => {
+    const builder: any = {
+      eq: vi.fn(() => builder),
+      select: vi.fn(() => Promise.resolve(selectResponse)),
+    };
+    builder.then = (resolve: any, reject: any) => Promise.resolve(thenResponse).then(resolve, reject);
+    return builder;
+  };
+
+  const createDeleteBuilder = (response: any) => {
+    const builder: any = {
+      eq: vi.fn(() => builder),
+    };
+    builder.then = (resolve: any, reject: any) => Promise.resolve(response).then(resolve, reject);
+    return builder;
+  };
+
+  return {
+    authMock,
+    fromMock,
+    channelMock,
+    removeChannelMock,
+    createSelectBuilder,
+    createUpdateBuilder,
+    createDeleteBuilder,
+  };
+});
+
+vi.mock('../../lib/supabase-client', () => ({
+  supabase: {
+    auth: mocks.authMock,
+    from: mocks.fromMock,
+    channel: mocks.channelMock,
+    removeChannel: mocks.removeChannelMock,
+  },
+}));
+
+import { notificationService } from '../notificationService';
+
+describe('notificationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authMock.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+  });
+
+  it('fetches sanitized notifications scoped to the authenticated user', async () => {
+    const notificationRows = [
+      {
+        id: 'notif-1',
+        user_id: 'user-1',
+        type: ' order_confirmation ',
+        title: '  Confirmation  ',
+        message: ' Thanks for your order ',
+        read: 'false',
+        read_at: null,
+        created_at: '2024-04-01T10:00:00.000Z',
+        updated_at: null,
+        priority: 'HIGH',
+        action_url: ' javascript:alert(1) ',
+        action_text: '  Voir  ',
+        metadata: {
+          action_url: 'https://example.com/orders/1',
+          order_id: 'order-1',
+          nested: { blocked: true },
+        },
+      },
+    ];
+    const selectBuilder = mocks.createSelectBuilder({ data: notificationRows, error: null });
+
+    mocks.fromMock.mockImplementation((table: string) => {
+      if (table === 'notifications') {
+        return selectBuilder;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await notificationService.getUserNotifications(150);
+
+    expect(mocks.authMock.getUser).toHaveBeenCalled();
+    expect(selectBuilder.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(selectBuilder.limit).toHaveBeenCalledWith(100);
+    expect(result).toHaveLength(1);
+    const [notification] = result;
+    expect(notification.read).toBe(false);
+    expect(notification.title).toBe('Confirmation');
+    expect(notification.action_url).toBeNull();
+    expect(notification.metadata?.action_url).toBe('https://example.com/orders/1');
+    expect(notification.priority).toBe('high');
+  });
+
+  it('marks notifications as read with sanitized identifiers and user scoping', async () => {
+    const updateBuilder = mocks.createUpdateBuilder({ data: [{ id: 'notif-1' }], error: null }, { error: null });
+
+    const updateMock = vi.fn(() => updateBuilder);
+    mocks.fromMock.mockImplementation((table: string) => {
+      if (table === 'notifications') {
+        return { update: updateMock } as any;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const updated = await notificationService.markAsRead('  notif-1  ');
+
+    expect(updated).toBe(true);
+    expect(updateBuilder.eq).toHaveBeenNthCalledWith(1, 'id', 'notif-1');
+    expect(updateBuilder.eq).toHaveBeenNthCalledWith(2, 'user_id', 'user-1');
+    expect(updateBuilder.select).toHaveBeenCalledWith('id');
+  });
+
+  it('returns false when no notification is updated', async () => {
+    const updateBuilder = mocks.createUpdateBuilder({ data: [], error: null }, { error: null });
+    const updateMock = vi.fn(() => updateBuilder);
+    mocks.fromMock.mockImplementation((table: string) => {
+      if (table === 'notifications') {
+        return { update: updateMock } as any;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const updated = await notificationService.markAsRead('notif-404');
+    expect(updated).toBe(false);
+  });
+
+  it('sanitizes notification preferences before persisting and when returning the result', async () => {
+    let upsertPayload: any;
+    const upsertMock = vi.fn((payload: any) => {
+      upsertPayload = payload;
+      return {
+        select: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: { email: 'true', push: 'false', types: ['  ALERT  '] },
+              error: null,
+            }),
+          ),
+        })),
+      } as any;
+    });
+
+    mocks.fromMock.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return { upsert: upsertMock } as any;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = await notificationService.updatePreferences({ email: true, push: false, types: [' alert ', 'ALERT'] });
+
+    expect(upsertPayload).toMatchObject({
+      user_id: 'user-1',
+      email: true,
+      push: false,
+      types: ['ALERT'],
+    });
+    expect(result).toEqual({ email: true, push: false, types: ['ALERT'] });
+  });
+
+  it('deletes notifications scoped to the authenticated user', async () => {
+    const deleteBuilder = mocks.createDeleteBuilder({ error: null });
+    const deleteMock = vi.fn(() => deleteBuilder);
+
+    mocks.fromMock.mockImplementation((table: string) => {
+      if (table === 'notifications') {
+        return { delete: deleteMock } as any;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    await notificationService.deleteNotification(' notif-2 ');
+
+    expect(deleteBuilder.eq).toHaveBeenNthCalledWith(1, 'id', 'notif-2');
+    expect(deleteBuilder.eq).toHaveBeenNthCalledWith(2, 'user_id', 'user-1');
+  });
+});

--- a/src/services/__tests__/orderService.test.ts
+++ b/src/services/__tests__/orderService.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const responses = {
+    profile: { data: { name: 'Test User', email: 'user@example.com', phone: '+221234567890' }, error: null as any },
+    ticketTypes: { data: [] as any[], error: null as any },
+    event: { data: { title: 'Concert Test', currency: 'XOF' }, error: null as any },
+    orderInsert: { data: { id: 'order-123' }, error: null as any },
+    orderDelete: { error: null as any },
+  };
+
+  const createListQuery = (getResponse: () => any) => {
+    const query: any = {};
+    query.select = vi.fn(() => query);
+    query.eq = vi.fn(() => query);
+    query.in = vi.fn(() => query);
+    query.then = (resolve: any, reject: any) => Promise.resolve(getResponse()).then(resolve, reject);
+    query.single = vi.fn(() => Promise.resolve(getResponse()));
+    return query;
+  };
+
+  const createSingleQuery = (getResponse: () => any) => {
+    const query: any = {};
+    query.select = vi.fn(() => query);
+    query.eq = vi.fn(() => query);
+    query.single = vi.fn(() => Promise.resolve(getResponse()));
+    query.then = (resolve: any, reject: any) => Promise.resolve(getResponse()).then(resolve, reject);
+    return query;
+  };
+
+  const createOrdersBuilder = () => ({
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(() => Promise.resolve(responses.orderInsert)),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      eq: vi.fn(() => Promise.resolve(responses.orderDelete)),
+    })),
+  });
+
+  let profileBuilder = createSingleQuery(() => responses.profile);
+  let ticketTypesBuilder = createListQuery(() => responses.ticketTypes);
+  let eventBuilder = createSingleQuery(() => responses.event);
+  let ordersBuilder = createOrdersBuilder();
+
+  const fromMock = vi.fn((table: string) => {
+    if (table === 'profiles') return profileBuilder;
+    if (table === 'ticket_types') return ticketTypesBuilder;
+    if (table === 'events') return eventBuilder;
+    if (table === 'orders') return ordersBuilder;
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  const reset = () => {
+    profileBuilder = createSingleQuery(() => responses.profile);
+    ticketTypesBuilder = createListQuery(() => responses.ticketTypes);
+    eventBuilder = createSingleQuery(() => responses.event);
+    ordersBuilder = createOrdersBuilder();
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'profiles') return profileBuilder;
+      if (table === 'ticket_types') return ticketTypesBuilder;
+      if (table === 'events') return eventBuilder;
+      if (table === 'orders') return ordersBuilder;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+  };
+
+  reset();
+
+  const getBuilders = () => ({ profileBuilder, ticketTypesBuilder, eventBuilder, ordersBuilder });
+
+  const authMock = {
+    getUser: vi.fn(),
+  };
+
+  const rpcMock = vi.fn();
+
+  const paymentMock = {
+    createPayment: vi.fn(),
+  };
+
+  return {
+    responses,
+    reset,
+    getBuilders,
+    authMock,
+    rpcMock,
+    paymentMock,
+    fromMock,
+  };
+});
+
+vi.mock('../../lib/supabase-client', () => ({
+  supabase: {
+    auth: mocks.authMock,
+    from: mocks.fromMock,
+    rpc: mocks.rpcMock,
+  },
+}));
+
+vi.mock('../paymentService', () => ({
+  paymentService: mocks.paymentMock,
+}));
+
+import { orderService } from '../orderService';
+
+const EVENT_ID = '22222222-2222-2222-2222-222222222222';
+const TICKET_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('orderService.createOrder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.responses.profile = { data: { name: 'Test User', email: 'user@example.com', phone: '+221234567890' }, error: null };
+    mocks.responses.ticketTypes = {
+      data: [
+        {
+          id: TICKET_ID,
+          event_id: EVENT_ID,
+          name: 'Standard',
+          price: 5000,
+          available: 10,
+          max_per_order: 5,
+          sales_enabled: true,
+          is_paused: false,
+          on_sale: true,
+          is_active: true,
+          status: 'AVAILABLE',
+        },
+      ],
+      error: null,
+    };
+    mocks.responses.event = { data: { title: 'Concert Test', currency: 'XOF' }, error: null };
+    mocks.responses.orderInsert = { data: { id: 'order-123' }, error: null };
+    mocks.responses.orderDelete = { error: null };
+    mocks.authMock.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mocks.paymentMock.createPayment.mockResolvedValue({ success: true, payment_url: 'https://pay', payment_token: 'token-1' });
+    mocks.reset();
+    vi.stubGlobal('crypto', {
+      randomUUID: vi.fn(() => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      getRandomValues: vi.fn((arr: Uint8Array) => arr.fill(1)),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects invalid payment method', async () => {
+    await expect(orderService.createOrder({
+      eventId: EVENT_ID,
+      ticketQuantities: { [TICKET_ID]: 1 },
+      paymentMethod: 'CASH',
+    } as any)).rejects.toThrow('Méthode de paiement invalide');
+
+    expect(mocks.paymentMock.createPayment).not.toHaveBeenCalled();
+  });
+
+  it('rejects when requested quantity exceeds availability', async () => {
+    mocks.responses.ticketTypes.data[0].available = 1;
+
+    await expect(orderService.createOrder({
+      eventId: EVENT_ID,
+      ticketQuantities: { [TICKET_ID]: 2 },
+      paymentMethod: 'CARD',
+    } as any)).rejects.toThrow('La quantité demandée pour « Standard » dépasse le stock disponible');
+  });
+
+  it('rejects when ticket sales are paused', async () => {
+    mocks.responses.ticketTypes.data[0].sales_enabled = false;
+
+    await expect(orderService.createOrder({
+      eventId: EVENT_ID,
+      ticketQuantities: { [TICKET_ID]: 1 },
+      paymentMethod: 'CARD',
+    } as any)).rejects.toThrow('Les billets « Standard » ne sont plus en vente');
+  });
+
+  it('creates the order and payment payload with sanitized values', async () => {
+    const result = await orderService.createOrder({
+      eventId: EVENT_ID,
+      ticketQuantities: { [TICKET_ID]: 2 },
+      paymentMethod: 'MOBILE_MONEY',
+      paymentDetails: { provider: 'orange', phone: ' 0777000000 ' },
+    });
+
+    expect(result.success).toBe(true);
+    const { ordersBuilder } = mocks.getBuilders();
+    expect(ordersBuilder.insert).toHaveBeenCalledTimes(1);
+    const insertedPayload = ordersBuilder.insert.mock.calls[0]?.[0];
+    expect(insertedPayload).toMatchObject({
+      user_id: 'user-1',
+      event_id: EVENT_ID,
+      ticket_quantities: { [TICKET_ID]: 2 },
+    });
+
+    expect(mocks.paymentMock.createPayment).toHaveBeenCalledTimes(1);
+    const paymentRequest = mocks.paymentMock.createPayment.mock.calls[0]?.[0];
+    expect(paymentRequest.ticket_lines).toEqual([
+      {
+        ticket_type_id: TICKET_ID,
+        quantity: 2,
+        price_major: 5000,
+        currency: 'XOF',
+      },
+    ]);
+    expect(paymentRequest.phone).toBe('0777000000');
+  });
+});
+
+describe('orderService.createGuestOrder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rpcMock.mockResolvedValue({ data: { success: true }, error: null });
+    vi.stubGlobal('crypto', {
+      randomUUID: vi.fn(() => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      getRandomValues: vi.fn((arr: Uint8Array) => arr.fill(1)),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects invalid ticket quantities before calling the RPC', async () => {
+    await expect(orderService.createGuestOrder({
+      email: 'guest@example.com',
+      name: 'Guest',
+      eventId: EVENT_ID,
+      ticketQuantities: { [TICKET_ID]: 0 },
+      paymentMethod: 'CARD',
+      paymentDetails: { cardNumber: '4111111111111111', expiryDate: '12/25', cvv: '123' },
+    })).rejects.toThrow('La quantité de billets doit être positive');
+
+    expect(mocks.rpcMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/services/eventAdminService.ts
+++ b/src/services/eventAdminService.ts
@@ -1,0 +1,277 @@
+import { z } from 'zod';
+import { supabase } from '../lib/supabase-client';
+import { CATEGORIES } from '../constants/categories';
+
+const CATEGORY_ID_SET = new Set(CATEGORIES.map(category => category.id));
+
+export const ADMIN_EVENT_CURRENCIES = ['GHS', 'USD', 'EUR', 'NGN'] as const;
+export const ADMIN_EVENT_STATUSES = ['DRAFT', 'PUBLISHED', 'CANCELLED', 'COMPLETED'] as const;
+
+const baseString = z.string({ required_error: 'Field is required' }).trim();
+
+const MAX_EVENT_PRICE = 1_000_000;
+const MAX_TICKET_PRICE = 1_000_000;
+const MAX_TICKET_QUANTITY = 1_000_000;
+const MAX_EVENT_CAPACITY = 1_000_000;
+
+const HTTPS_PROTOCOL = 'https://';
+
+const finiteMoney = (minimumMessage: string, invalidMessage: string, maxMessage: string, maxValue: number) =>
+  z
+    .number()
+    .finite({ message: invalidMessage })
+    .min(0, minimumMessage)
+    .max(maxValue, maxMessage);
+
+const boundedInteger = (
+  minimum: number,
+  minimumMessage: string,
+  maxMessage: string,
+  wholeNumberMessage: string,
+) =>
+  z
+    .number()
+    .int({ message: wholeNumberMessage })
+    .min(minimum, minimumMessage)
+    .max(MAX_TICKET_QUANTITY, maxMessage);
+
+export const adminTicketTypeSchema = z
+  .object({
+    id: z.string().uuid().optional(),
+    name: baseString.min(1, 'Ticket name is required').max(120, 'Ticket name is too long'),
+    description: baseString.min(1, 'Ticket description is required'),
+    price: finiteMoney(
+      'Ticket price cannot be negative',
+      'Ticket price must be a valid amount',
+      'Ticket price exceeds supported limits',
+      MAX_TICKET_PRICE,
+    ),
+    quantity: boundedInteger(
+      0,
+      'Ticket quantity cannot be negative',
+      'Ticket quantity exceeds supported limits',
+      'Ticket quantity must be a whole number',
+    ),
+    available: boundedInteger(
+      0,
+      'Available tickets cannot be negative',
+      'Available tickets exceed supported limits',
+      'Available tickets must be a whole number',
+    ),
+    max_per_order: boundedInteger(
+      1,
+      'Max per order must be at least 1',
+      'Max per order exceeds supported limits',
+      'Max per order must be a whole number',
+    ),
+  })
+  .superRefine((ticket, ctx) => {
+    if (ticket.available > ticket.quantity) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['available'],
+        message: 'Available tickets cannot exceed total quantity',
+      });
+    }
+
+    if (ticket.max_per_order > ticket.quantity) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['max_per_order'],
+        message: 'Max per order cannot exceed total quantity',
+      });
+    }
+  });
+
+const categoriesSchema = z
+  .array(baseString.min(1))
+  .optional()
+  .transform(values => {
+    if (!values) {
+      return [] as string[];
+    }
+
+    const unique: string[] = [];
+    const seen = new Set<string>();
+
+    for (const value of values) {
+      if (!seen.has(value)) {
+        unique.push(value);
+        seen.add(value);
+      }
+    }
+
+    return unique;
+  })
+  .superRefine((values, ctx) => {
+    values.forEach((value, index) => {
+      if (!CATEGORY_ID_SET.has(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index],
+          message: `Unknown category: ${value}`,
+        });
+      }
+    });
+  });
+
+export const adminEventSchema = z.object({
+  title: baseString.min(1, 'Title is required').max(180, 'Title is too long'),
+  description: baseString.min(1, 'Description is required'),
+  date: baseString.regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u, 'Invalid date format (expected YYYY-MM-DD)'),
+  time: baseString.regex(/^[0-9]{2}:[0-9]{2}$/u, 'Invalid time format (expected HH:MM)'),
+  location: baseString.min(1, 'Location is required'),
+  image_url: baseString
+    .url('A valid image URL is required')
+    .refine(url => url.toLowerCase().startsWith(HTTPS_PROTOCOL), 'Image URL must use HTTPS'),
+  price: finiteMoney(
+    'Price cannot be negative',
+    'Event price must be a valid amount',
+    'Event price exceeds supported limits',
+    MAX_EVENT_PRICE,
+  ),
+  currency: z.enum(ADMIN_EVENT_CURRENCIES),
+  capacity: z
+    .number()
+    .int({ message: 'Capacity must be a whole number' })
+    .min(1, 'Capacity must be at least 1')
+    .max(MAX_EVENT_CAPACITY, 'Capacity exceeds supported limits'),
+  status: z.enum(ADMIN_EVENT_STATUSES).default('DRAFT'),
+  featured: z.boolean().optional().default(false),
+  organizer_id: z
+    .string()
+    .uuid({ message: 'Organizer identifier must be a valid UUID' })
+    .optional()
+    .nullable()
+    .transform(value => value ?? null),
+  categories: categoriesSchema.default([]),
+  ticket_types: z.array(adminTicketTypeSchema).min(1, 'At least one ticket type is required'),
+});
+
+export type AdminTicketTypeInput = z.infer<typeof adminTicketTypeSchema>;
+export type AdminEventInput = z.infer<typeof adminEventSchema>;
+
+const clampAvailability = (ticket: AdminTicketTypeInput) => ({
+  ...ticket,
+  available: Math.min(ticket.available, ticket.quantity),
+});
+
+export async function createAdminEvent(input: AdminEventInput) {
+  const parsed = adminEventSchema.parse(input);
+  const { ticket_types, organizer_id, categories, featured = false, ...eventFields } = parsed;
+
+  const eventPayload = {
+    ...eventFields,
+    featured,
+    organizer_id,
+    categories,
+  };
+
+  const insertBuilder = supabase
+    .from('events')
+    .insert([eventPayload])
+    .select('id')
+    .maybeSingle();
+
+  const { data, error } = await insertBuilder;
+
+  if (error) {
+    throw new Error(error.message || 'Failed to create event');
+  }
+
+  const eventId = data?.id;
+
+  if (!eventId) {
+    throw new Error('Failed to retrieve created event identifier');
+  }
+
+  const ticketPayload = ticket_types.map(ticket => {
+    const sanitized = clampAvailability(ticket);
+    return {
+      event_id: eventId,
+      name: sanitized.name,
+      description: sanitized.description,
+      price: sanitized.price,
+      quantity: sanitized.quantity,
+      available: sanitized.available,
+      max_per_order: sanitized.max_per_order,
+    };
+  });
+
+  const { error: ticketError } = await supabase.from('ticket_types').insert(ticketPayload);
+
+  if (ticketError) {
+    await supabase.from('events').delete().eq('id', eventId);
+    throw new Error(ticketError.message || 'Failed to create ticket types');
+  }
+
+  return eventId;
+}
+
+export async function updateAdminEvent(
+  eventId: string,
+  input: AdminEventInput,
+  existingTicketTypeIds: string[] = [],
+) {
+  const parsed = adminEventSchema.parse(input);
+  const { ticket_types, organizer_id, categories, featured = false, ...eventFields } = parsed;
+
+  const { error: eventError } = await supabase
+    .from('events')
+    .update({
+      ...eventFields,
+      featured,
+      organizer_id,
+      categories,
+    })
+    .eq('id', eventId);
+
+  if (eventError) {
+    throw new Error(eventError.message || 'Failed to update event');
+  }
+
+  const sanitizedTickets = ticket_types.map(ticket => ({
+    ...clampAvailability(ticket),
+    event_id: eventId,
+  }));
+
+  const ticketsToUpsert = sanitizedTickets.filter(ticket => ticket.id);
+  if (ticketsToUpsert.length > 0) {
+    const { error: upsertError } = await supabase
+      .from('ticket_types')
+      .upsert(ticketsToUpsert, { onConflict: 'id' });
+
+    if (upsertError) {
+      throw new Error(upsertError.message || 'Failed to update ticket types');
+    }
+  }
+
+  const ticketsToInsert = sanitizedTickets
+    .filter(ticket => !ticket.id)
+    .map(({ id: _id, ...ticket }) => ticket);
+
+  if (ticketsToInsert.length > 0) {
+    const { error: insertError } = await supabase.from('ticket_types').insert(ticketsToInsert);
+    if (insertError) {
+      throw new Error(insertError.message || 'Failed to create new ticket types');
+    }
+  }
+
+  const incomingIds = new Set(
+    sanitizedTickets
+      .map(ticket => ticket.id)
+      .filter((id): id is string => typeof id === 'string'),
+  );
+  const ticketsToDelete = existingTicketTypeIds.filter(id => !incomingIds.has(id));
+
+  if (ticketsToDelete.length > 0) {
+    const { error: deleteError } = await supabase
+      .from('ticket_types')
+      .delete()
+      .in('id', ticketsToDelete);
+
+    if (deleteError) {
+      throw new Error(deleteError.message || 'Failed to remove old ticket types');
+    }
+  }
+}

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,6 +1,92 @@
 import { supabase } from '../lib/supabase-client';
 import { paymentService, CreatePaymentRequest } from './paymentService';
-import { notificationTriggers } from './notificationTriggers';
+import { z } from 'zod';
+
+const uuidSchema = z.string().uuid("ID d'événement invalide");
+const MAX_TICKETS_PER_TYPE = 1_000;
+
+const ticketQuantitiesSchema = z.record(
+  z.string().uuid('Identifiant de billet invalide'),
+  z.coerce
+    .number({ invalid_type_error: 'La quantité de billets doit être un nombre' })
+    .int('La quantité de billets doit être un nombre entier')
+    .positive('La quantité de billets doit être positive')
+    .max(MAX_TICKETS_PER_TYPE, `Impossible de commander plus de ${MAX_TICKETS_PER_TYPE} billets par type`)
+);
+
+const allowedPaymentMethods = new Set(['MOBILE_MONEY', 'CARD']);
+
+const normalizePaymentMethod = (method: string) => {
+  const normalized = method?.trim().toUpperCase();
+  if (!allowedPaymentMethods.has(normalized)) {
+    throw new Error('Méthode de paiement invalide');
+  }
+  return normalized as 'MOBILE_MONEY' | 'CARD';
+};
+
+const sanitizeTicketQuantities = (quantities: { [key: string]: number }) => {
+  const parsed = ticketQuantitiesSchema.safeParse(quantities);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new Error(issue?.message || 'Quantités de billets invalides');
+  }
+  if (Object.keys(parsed.data).length === 0) {
+    throw new Error('Aucun billet sélectionné');
+  }
+  return parsed.data;
+};
+
+const createSecureIdempotencyKey = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return `payment-${globalThis.crypto.randomUUID()}`;
+  }
+
+  if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+    return `payment-${hex}`;
+  }
+
+  throw new Error('Générateur aléatoire sécurisé indisponible');
+};
+
+interface TicketTypeRow {
+  id: string;
+  event_id: string;
+  name: string;
+  price: number;
+  available: number | null;
+  max_per_order: number | null;
+  sales_enabled?: boolean | null;
+  is_paused?: boolean | null;
+  on_sale?: boolean | null;
+  is_active?: boolean | null;
+  status?: string | null;
+}
+
+const isTicketPaused = (ticket: TicketTypeRow) =>
+  ticket.sales_enabled === false ||
+  ticket.is_paused === true ||
+  ticket.on_sale === false ||
+  ticket.is_active === false ||
+  ticket.status === 'PAUSED';
+
+const normalizeAvailable = (ticket: TicketTypeRow) => {
+  const available = Number(ticket.available ?? 0);
+  if (!Number.isFinite(available) || available < 0) {
+    return 0;
+  }
+  return Math.floor(available);
+};
+
+const normalizeMaxPerOrder = (ticket: TicketTypeRow) => {
+  const max = ticket.max_per_order == null ? null : Number(ticket.max_per_order);
+  if (max == null || !Number.isFinite(max) || max <= 0) {
+    return Infinity;
+  }
+  return Math.floor(max);
+};
 
 export interface CreateOrderInput {
   eventId: string;
@@ -21,12 +107,21 @@ class OrderService {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error('Non authentifié');
 
-      // Validate input
-      if (!input.eventId) throw new Error('ID d\'événement requis');
+      if (!input.eventId) throw new Error("ID d'événement requis");
+
+      const eventIdResult = uuidSchema.safeParse(input.eventId.trim());
+      if (!eventIdResult.success) {
+        throw new Error("ID d'événement invalide");
+      }
+      const eventId = eventIdResult.data;
+
       if (!input.ticketQuantities || Object.keys(input.ticketQuantities).length === 0) {
         throw new Error('Aucun billet sélectionné');
       }
-      if (!input.paymentMethod) throw new Error('Méthode de paiement requise');
+
+      const ticketQuantities = sanitizeTicketQuantities(input.ticketQuantities);
+
+      const paymentMethod = normalizePaymentMethod(input.paymentMethod);
 
       // Get user profile for payment
       const { data: profile } = await supabase
@@ -37,24 +132,66 @@ class OrderService {
 
       if (!profile) throw new Error('Profil utilisateur non trouvé');
 
-      // Calculate total amount
-      const { data: ticketTypes } = await supabase
+      const requestedTicketIds = Object.keys(ticketQuantities);
+
+      const { data: ticketTypes, error: ticketError } = await supabase
         .from('ticket_types')
-        .select('id, price')
-        .in('id', Object.keys(input.ticketQuantities));
+        .select('id, event_id, name, price, available, max_per_order, sales_enabled, is_paused, on_sale, is_active, status')
+        .eq('event_id', eventId)
+        .in('id', requestedTicketIds);
 
-      if (!ticketTypes) throw new Error('Types de billets non trouvés');
+      if (ticketError) throw ticketError;
+      if (!ticketTypes || ticketTypes.length === 0) {
+        throw new Error('Types de billets non trouvés');
+      }
 
-      const totalAmount = ticketTypes.reduce((sum, ticket) => {
-        const quantity = input.ticketQuantities[ticket.id] || 0;
-        return sum + (ticket.price * quantity);
-      }, 0);
+      const fetchedIds = new Set(ticketTypes.map((ticket) => ticket.id));
+      const missingIds = requestedTicketIds.filter((id) => !fetchedIds.has(id));
+      if (missingIds.length > 0) {
+        throw new Error('Certains billets sélectionnés sont introuvables ou ne sont plus disponibles');
+      }
+
+      let totalAmount = 0;
+
+      for (const ticket of ticketTypes as TicketTypeRow[]) {
+        if (ticket.event_id !== eventId) {
+          throw new Error('Certains billets sélectionnés ne correspondent pas à cet événement');
+        }
+
+        const quantity = ticketQuantities[ticket.id];
+        if (!quantity) continue;
+
+        if (isTicketPaused(ticket)) {
+          throw new Error(`Les billets « ${ticket.name} » ne sont plus en vente`);
+        }
+
+        const available = normalizeAvailable(ticket);
+        if (available < quantity) {
+          throw new Error(`La quantité demandée pour « ${ticket.name} » dépasse le stock disponible`);
+        }
+
+        const maxPerOrder = normalizeMaxPerOrder(ticket);
+        if (quantity > maxPerOrder) {
+          throw new Error(`Impossible de commander plus de ${maxPerOrder} billets pour « ${ticket.name} »`);
+        }
+
+        const price = Number(ticket.price);
+        if (!Number.isFinite(price) || price < 0) {
+          throw new Error(`Prix invalide pour le billet « ${ticket.name} »`);
+        }
+
+        totalAmount += price * quantity;
+      }
+
+      if (totalAmount <= 0) {
+        throw new Error('Le total de la commande doit être supérieur à zéro');
+      }
 
       // Get event details
       const { data: event } = await supabase
         .from('events')
         .select('title, currency')
-        .eq('id', input.eventId)
+        .eq('id', eventId)
         .single();
 
       if (!event) throw new Error('Événement non trouvé');
@@ -64,11 +201,11 @@ class OrderService {
         .from('orders')
         .insert({
           user_id: user.id,
-          event_id: input.eventId,
+          event_id: eventId,
           total: totalAmount,
           status: 'PENDING',
-          payment_method: input.paymentMethod,
-          ticket_quantities: input.ticketQuantities
+          payment_method: paymentMethod,
+          ticket_quantities: ticketQuantities
         })
         .select()
         .single();
@@ -77,40 +214,40 @@ class OrderService {
 
       // Create payment using edge function
       // Build ticket lines for the edge function
-      const ticketLines = ticketTypes.map(ticket => ({
-        ticket_type_id: ticket.id,
-        quantity: input.ticketQuantities[ticket.id] || 0,
-        price_major: ticket.price,
-        currency: event.currency
-      })).filter(line => line.quantity > 0);
-
-      console.log('Ticket types from database:', ticketTypes);
-      console.log('Input ticket quantities:', input.ticketQuantities);
-      console.log('Generated ticket lines:', ticketLines);
+      const ticketLines = (ticketTypes as TicketTypeRow[])
+        .map(ticket => ({
+          ticket_type_id: ticket.id,
+          quantity: ticketQuantities[ticket.id] || 0,
+          price_major: Number(ticket.price),
+          currency: event.currency
+        }))
+        .filter(line => line.quantity > 0);
 
       const paymentRequest: CreatePaymentRequest = {
-        idempotency_key: `payment-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        idempotency_key: createSecureIdempotencyKey(),
         user_id: user.id,
-        event_id: input.eventId,
+        event_id: eventId,
         order_id: orderData.id,
         ticket_lines: ticketLines,
         amount_major: totalAmount,
         currency: event.currency,
-        method: input.paymentMethod === 'MOBILE_MONEY' ? 'mobile_money' : 'credit_card',
-        phone: input.paymentDetails?.phone || profile.phone,
-        provider: input.paymentDetails?.provider,
+        method: paymentMethod === 'MOBILE_MONEY' ? 'mobile_money' : 'credit_card',
+        phone: input.paymentDetails?.phone?.trim() || profile.phone?.trim(),
+        provider: input.paymentDetails?.provider?.trim(),
         save_method: false,
         return_url: `${window.location.origin}/payment/success`,
         cancel_url: `${window.location.origin}/payment/cancelled`,
         description: `Tickets for ${event.title}`
       };
 
-      console.log('Creating payment with request:', paymentRequest);
       const paymentResponse = await paymentService.createPayment(paymentRequest);
 
       if (!paymentResponse.success) {
         // Delete the order if payment creation failed
-        await supabase.from('orders').delete().eq('id', orderData.id);
+        const { error: rollbackError } = await supabase.from('orders').delete().eq('id', orderData.id);
+        if (rollbackError) {
+          console.error('Échec du nettoyage de la commande après un paiement refusé:', rollbackError);
+        }
         throw new Error(paymentResponse.error || 'Failed to create payment');
       }
 
@@ -146,21 +283,29 @@ class OrderService {
       // Input validation
       if (!input.email?.trim()) throw new Error('Email requis');
       if (!input.name?.trim()) throw new Error('Nom requis');
-      if (!input.eventId) throw new Error('ID d\'événement requis');
+      if (!input.eventId) throw new Error("ID d'événement requis");
       if (!input.ticketQuantities || Object.keys(input.ticketQuantities).length === 0) {
         throw new Error('Aucun billet sélectionné');
       }
-      if (!input.paymentMethod) throw new Error('Méthode de paiement requise');
+
+      const eventIdResult = uuidSchema.safeParse(input.eventId.trim());
+      if (!eventIdResult.success) {
+        throw new Error("ID d'événement invalide");
+      }
+
+      const ticketQuantities = sanitizeTicketQuantities(input.ticketQuantities);
+
+      const paymentMethod = normalizePaymentMethod(input.paymentMethod);
 
       // Validate email format
       const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
       if (!emailRegex.test(input.email)) throw new Error('Format d\'email invalide');
 
       // Validate payment details
-      if (input.paymentMethod === 'MOBILE_MONEY') {
+      if (paymentMethod === 'MOBILE_MONEY') {
         if (!input.paymentDetails?.provider) throw new Error('Fournisseur de paiement requis');
         if (!input.paymentDetails?.phone) throw new Error('Numéro de téléphone requis');
-      } else if (input.paymentMethod === 'CARD') {
+      } else if (paymentMethod === 'CARD') {
         if (!input.paymentDetails?.cardNumber) throw new Error('Numéro de carte requis');
         if (!input.paymentDetails?.expiryDate) throw new Error('Date d\'expiration de la carte requise');
         if (!input.paymentDetails?.cvv) throw new Error('CVV de la carte requis');
@@ -171,9 +316,9 @@ class OrderService {
         p_email: input.email.trim(),
         p_name: input.name.trim(),
         p_phone: input.phone?.trim(),
-        p_event_id: input.eventId,
-        p_payment_method: input.paymentMethod,
-        p_ticket_quantities: input.ticketQuantities,
+        p_event_id: eventIdResult.data,
+        p_payment_method: paymentMethod,
+        p_ticket_quantities: ticketQuantities,
         p_payment_details: input.paymentDetails || {}
       });
 

--- a/src/services/serviceFeeService.ts
+++ b/src/services/serviceFeeService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase-client';
+import { z } from 'zod';
 
 export interface ServiceFeeSelection {
   ticket_type_id: string;
@@ -25,10 +26,39 @@ export interface ServiceFeeResult {
 
 class ServiceFeeService {
   async calculateFees(eventId: string, selections: ServiceFeeSelection[]): Promise<ServiceFeeResult> {
+    const eventIdSchema = z.string().uuid('Identifiant événement invalide');
+    const selectionSchema = z.object({
+      ticket_type_id: z.string().uuid('Identifiant de type de billet invalide'),
+      quantity: z.number({ invalid_type_error: 'Quantité invalide' }).int('Quantité invalide').positive('La quantité doit être positive').max(1_000, 'Quantité de billets trop élevée'),
+      price: z.number({ invalid_type_error: 'Prix invalide' }).finite('Prix invalide')
+    });
+
+    const parsedEventId = eventIdSchema.safeParse(eventId?.trim());
+    if (!parsedEventId.success) {
+      throw new Error(parsedEventId.error.issues[0]?.message || 'Identifiant événement invalide');
+    }
+
+    const sanitizedSelections = selections
+      .map(selection => ({
+        ticket_type_id: selection.ticket_type_id?.trim?.() ?? '',
+        quantity: Number(selection.quantity),
+        price: Number(selection.price)
+      }))
+      .filter(selection => selection.quantity > 0);
+
+    const parsedSelections = z.array(selectionSchema).max(200, 'Trop de billets sélectionnés').safeParse(sanitizedSelections);
+    if (!parsedSelections.success) {
+      throw new Error(parsedSelections.error.issues[0]?.message || 'Sélection de billets invalide');
+    }
+
+    if (parsedSelections.data.length === 0) {
+      return { total_buyer_fees: 0, total_organizer_fees: 0, fee_breakdown: [] };
+    }
+
     try {
       const { data, error } = await supabase.rpc('calculate_service_fees', {
-        p_event_id: eventId,
-        p_ticket_selections: selections
+        p_event_id: parsedEventId.data,
+        p_ticket_selections: parsedSelections.data
       });
 
       if (error) throw error;
@@ -46,7 +76,7 @@ class ServiceFeeService {
       // Fallback path: derive from active service_fee_rules (supports TICKET_TYPE > EVENT > GLOBAL)
       try {
         // Fetch relevant rules via three reliable queries
-        const ticketTypeIds = selections.map(s => s.ticket_type_id);
+        const ticketTypeIds = parsedSelections.data.map(s => s.ticket_type_id);
 
         const [{ data: ttRules, error: ttErr }, { data: evRules, error: evErr }, { data: globalRules, error: glErr }] = await Promise.all([
           supabase.from('service_fee_rules').select('*').eq('active', true).eq('scope', 'TICKET_TYPE').in('ticket_type_id', ticketTypeIds.length ? ticketTypeIds : ['00000000-0000-0000-0000-000000000000']),
@@ -72,7 +102,7 @@ class ServiceFeeService {
         let totalOrg = 0;
         const breakdown: ServiceFeeBreakdownItem[] = [];
 
-        for (const s of selections) {
+        for (const s of parsedSelections.data) {
           const rule: any = pickRule(s.ticket_type_id);
           if (!rule) continue;
           let feeAmount = 0;
@@ -108,7 +138,7 @@ class ServiceFeeService {
         };
       } catch (fallbackErr) {
         console.error('Table-based fee fallback failed, using minimal 2% fallback:', fallbackErr);
-        const subtotal = selections.reduce((sum, s) => sum + s.price * s.quantity, 0);
+        const subtotal = parsedSelections.data.reduce((sum, s) => sum + s.price * s.quantity, 0);
         return {
           total_buyer_fees: subtotal * 0.02,
           total_organizer_fees: 0,
@@ -120,5 +150,6 @@ class ServiceFeeService {
 }
 
 export const serviceFeeService = new ServiceFeeService();
+
 
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -1,0 +1,8 @@
+export interface BookingLineItem {
+  id: string;
+  name: string;
+  description?: string | null;
+  price: number;
+  quantity: number;
+}
+

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,3 +1,5 @@
+import type { CategoryId } from '../constants/categories';
+
 export interface EventCategory {
   id: string;
   name: string;
@@ -7,6 +9,12 @@ export interface EventCategory {
   subcategories?: string[]; // Array of subcategory names
   created_at?: string;
   updated_at?: string;
+}
+
+export interface EventOrganizer {
+  user_id: string;
+  name: string;
+  email: string;
 }
 
 export interface Event {
@@ -23,13 +31,18 @@ export interface Event {
   tickets_sold: number;
   status: 'DRAFT' | 'PUBLISHED' | 'CANCELLED' | 'COMPLETED';
   featured: boolean;
-  categories?: string[]; // Array of category IDs (legacy support)
+  categories?: CategoryId[] | null; // Array of category IDs (legacy support)
   category_relations?: EventCategory[]; // New normalized categories
   ticket_types?: TicketType[];
   coordinates?: {
     latitude: number;
     longitude: number;
   };
+  organizer_id?: string | null;
+  organizer?: EventOrganizer | null;
+  avg_rating?: number | null;
+  review_count?: number | null;
+  venue_layout_id?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -63,7 +76,7 @@ export interface CreateEventInput {
   price: number;
   currency: string;
   capacity: number;
-  categories: string[];
+  categories: CategoryId[];
   coordinates?: {
     latitude: number;
     longitude: number;
@@ -71,8 +84,4 @@ export interface CreateEventInput {
   ticket_types: Omit<TicketType, 'id' | 'event_id' | 'created_at' | 'updated_at'>[];
 }
 
-export interface CategoryId {
-  id: string;
-}
-
-export type CategoryIdType = typeof CATEGORIES[number]['id'];
+export type CategoryIdType = CategoryId;

--- a/src/utils/__tests__/notificationSanitizers.test.ts
+++ b/src/utils/__tests__/notificationSanitizers.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  coerceToBoolean,
+  parsePriority,
+  sanitizeActionText,
+  sanitizeActionUrl,
+  sanitizeMetadata,
+  sanitizePreferenceTypes,
+  sanitizeTitle,
+} from '../notificationSanitizers';
+
+describe('notificationSanitizers', () => {
+  it('coerces various values to booleans safely', () => {
+    expect(coerceToBoolean(true)).toBe(true);
+    expect(coerceToBoolean('true')).toBe(true);
+    expect(coerceToBoolean('YES')).toBe(true);
+    expect(coerceToBoolean('false')).toBe(false);
+    expect(coerceToBoolean(0)).toBe(false);
+    expect(coerceToBoolean(undefined)).toBe(false);
+  });
+
+  it('sanitizes action urls to safe http(s) or relative values', () => {
+    expect(sanitizeActionUrl('/events/123')).toBe('/events/123');
+    expect(sanitizeActionUrl('https://example.com/path')).toBe('https://example.com/path');
+    expect(sanitizeActionUrl('   javascript:alert(1)   ')).toBeNull();
+    expect(sanitizeActionUrl('ftp://example.com')).toBeNull();
+  });
+
+  it('sanitizes metadata values and strips unsupported entries', () => {
+    const sanitized = sanitizeMetadata({
+      action_url: 'javascript:alert(1)',
+      action_text: '  View ',
+      count: 2,
+      nested: { bad: true },
+      description: '   Something happened   ',
+    });
+
+    expect(sanitized).toEqual({
+      action_text: 'View',
+      count: 2,
+      description: 'Something happened',
+    });
+  });
+
+  it('sanitizes preference types by trimming, deduping, and limiting entries', () => {
+    const types = sanitizePreferenceTypes([' EVENT ', 'event', 'ALERT', 42 as unknown as string]);
+    expect(types).toEqual(['EVENT', 'ALERT']);
+  });
+
+  it('parses notification priority with a safe fallback', () => {
+    expect(parsePriority('high')).toBe('high');
+    expect(parsePriority('invalid')).toBe('normal');
+  });
+
+  it('sanitizes action text and titles with fallbacks', () => {
+    expect(sanitizeActionText('  Voir  ')).toBe('Voir');
+    expect(sanitizeActionText('   ')).toBeNull();
+    expect(sanitizeTitle('   ')).toBe('Notification');
+  });
+});

--- a/src/utils/__tests__/supabaseFilters.test.ts
+++ b/src/utils/__tests__/supabaseFilters.test.ts
@@ -1,0 +1,31 @@
+import { buildTextSearchFilter, sanitizeTextSearchTerm } from '../supabaseFilters';
+
+describe('sanitizeTextSearchTerm', () => {
+  it('removes dangerous characters and normalizes whitespace', () => {
+    expect(sanitizeTextSearchTerm("  party%; DROP TABLE  ")).toBe('party DROP TABLE');
+  });
+
+  it('preserves unicode characters and digits', () => {
+    expect(sanitizeTextSearchTerm('Fête Élite 2024!')).toBe('Fête Élite 2024');
+  });
+
+  it('truncates overly long input to the default maximum length', () => {
+    const long = 'a'.repeat(300);
+    expect(sanitizeTextSearchTerm(long)).toHaveLength(120);
+  });
+});
+
+describe('buildTextSearchFilter', () => {
+  it('returns null when the sanitized term is empty', () => {
+    expect(buildTextSearchFilter(['title', 'description'], '!!!')).toBeNull();
+  });
+
+  it('builds a safe ilike filter for provided columns', () => {
+    expect(buildTextSearchFilter(['title', 'description'], 'music')).toBe('title.ilike.%music%,description.ilike.%music%');
+  });
+
+  it('sanitizes characters that could break the filter expression', () => {
+    expect(buildTextSearchFilter(['title'], "Summer, status.eq.DRAFT"))
+      .toBe('title.ilike.%Summer status.eq.DRAFT%');
+  });
+});

--- a/src/utils/notificationSanitizers.ts
+++ b/src/utils/notificationSanitizers.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+
+export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+const TRUE_VALUES = new Set(['true', 't', '1', 'yes', 'y']);
+const FALSE_VALUES = new Set(['false', 'f', '0', 'no', 'n']);
+const MAX_METADATA_KEYS = 25;
+const MAX_TEXT_LENGTH = 1024;
+const MAX_ACTION_TEXT_LENGTH = 120;
+const MAX_TITLE_LENGTH = 255;
+const MAX_MESSAGE_LENGTH = 2000;
+const MAX_URL_LENGTH = 2048;
+
+const metadataValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+type MetadataRecord = Record<string, unknown>;
+
+export const coerceToBoolean = (value: unknown): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (TRUE_VALUES.has(normalized)) return true;
+    if (FALSE_VALUES.has(normalized)) return false;
+  }
+  return false;
+};
+
+export const parsePriority = (value: unknown): NotificationPriority => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'low' || normalized === 'normal' || normalized === 'high' || normalized === 'urgent') {
+      return normalized;
+    }
+  }
+  return 'normal';
+};
+
+export const sanitizeText = (value: unknown, fallback: string, maxLength = MAX_TEXT_LENGTH): string => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return trimmed.slice(0, Math.max(1, maxLength));
+};
+
+export const sanitizeActionText = (value: unknown): string | null => {
+  const sanitized = sanitizeText(value, '', MAX_ACTION_TEXT_LENGTH);
+  return sanitized ? sanitized : null;
+};
+
+export const sanitizeActionUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_URL_LENGTH) {
+    return null;
+  }
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.toString();
+    }
+  } catch (error) {
+    return null;
+  }
+
+  return null;
+};
+
+export const sanitizeMetadata = (value: unknown): MetadataRecord | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const entries: [string, unknown][] = [];
+  for (const [key, raw] of Object.entries(value)) {
+    if (entries.length >= MAX_METADATA_KEYS) {
+      break;
+    }
+
+    if (typeof key !== 'string') {
+      continue;
+    }
+
+    const sanitizedKey = key.trim().slice(0, 64);
+    if (!sanitizedKey) {
+      continue;
+    }
+
+    if (!metadataValueSchema.safeParse(raw).success) {
+      continue;
+    }
+
+    if (sanitizedKey === 'action_url') {
+      const url = sanitizeActionUrl(raw);
+      if (url) {
+        entries.push([sanitizedKey, url]);
+      }
+      continue;
+    }
+
+    if (sanitizedKey === 'action_text') {
+      const actionText = sanitizeActionText(raw);
+      if (actionText) {
+        entries.push([sanitizedKey, actionText]);
+      }
+      continue;
+    }
+
+    if (typeof raw === 'string') {
+      entries.push([sanitizedKey, raw.trim().slice(0, MAX_TEXT_LENGTH)]);
+      continue;
+    }
+
+    entries.push([sanitizedKey, raw]);
+  }
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+};
+
+export const sanitizePreferenceTypes = (value: unknown, limit = 20): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const sanitized: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+
+    const normalized = entry.trim().slice(0, 64);
+    if (!normalized) {
+      continue;
+    }
+
+    const key = normalized.toUpperCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      sanitized.push(key);
+    }
+
+    if (sanitized.length >= limit) {
+      break;
+    }
+  }
+
+  return sanitized;
+};
+
+export const sanitizeTitle = (value: unknown): string => sanitizeText(value, 'Notification', MAX_TITLE_LENGTH);
+
+export const sanitizeMessage = (value: unknown, fallbackTitle: string): string =>
+  sanitizeText(value, `Nouvelle notification : ${fallbackTitle}`, MAX_MESSAGE_LENGTH);

--- a/src/utils/supabaseFilters.ts
+++ b/src/utils/supabaseFilters.ts
@@ -1,0 +1,48 @@
+const DEFAULT_MAX_LENGTH = 120;
+
+/**
+ * Normalizes user-provided search terms before using them inside Supabase filter strings.
+ * Removes potentially dangerous characters that could break the filter syntax while
+ * preserving useful unicode characters for legitimate searches.
+ */
+export function sanitizeTextSearchTerm(rawTerm: string, maxLength: number = DEFAULT_MAX_LENGTH): string {
+  if (!rawTerm) {
+    return '';
+  }
+
+  const normalized = rawTerm
+    .normalize('NFKC')
+    // Replace characters that have special meaning inside filter expressions
+    // or that may cause parsing issues.
+    .replace(/["'`%\\]/g, ' ')
+    // Replace parentheses, semicolons and equal signs to avoid expression injection.
+    .replace(/[()\[\];=]/g, ' ');
+
+  const filtered = normalized
+    // Allow letters (including diacritics), numbers, spaces and a handful of safe symbols.
+    .replace(/[^\p{L}\p{N}\s\-_.]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!filtered) {
+    return '';
+  }
+
+  return filtered.slice(0, maxLength);
+}
+
+/**
+ * Builds a safe `or` filter segment for Supabase text search using `ilike`.
+ * Returns `null` when the sanitized term is empty.
+ */
+export function buildTextSearchFilter(columns: string[], rawTerm: string): string | null {
+  const sanitized = sanitizeTextSearchTerm(rawTerm);
+  if (!sanitized) {
+    return null;
+  }
+
+  const pattern = `%${sanitized}%`;
+  const escapedPattern = pattern.replace(/,/g, '\\,');
+
+  return columns.map(column => `${column}.ilike.${escapedPattern}`).join(',');
+}


### PR DESCRIPTION
## Summary
- add reusable notification sanitizers and Zod-backed parsing in the notification service to scope queries to the active user, coerce boolean flags, and normalise metadata and preferences
- refactor the notification provider, bell, and listing views to consume the hardened service, dedupe realtime payloads, and safely navigate using validated metadata
- validate notification trigger payloads before insertion and add focused Vitest coverage for the sanitizers and notification service flows

## Testing
- npm test -- --run
- npm run lint *(fails: project lint script still passes the deprecated --ext flag when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbfc078c8320904b90536ac8fd4c